### PR TITLE
Fix last card dropped when document ends on a card block (#25)

### DIFF
--- a/app/logic/utils.py
+++ b/app/logic/utils.py
@@ -51,7 +51,13 @@ def read_file(file: Path) -> str:
 
 
 def parse_markdown_file(file_path: Path) -> Tuple[dict, str]:
-    """Parse a markdown file into metadata and body."""
+    """Parse a markdown file into metadata and body.
+
+    The returned body is guaranteed to be newline-terminated when non-empty.
+    The chunk-extraction regexes depend on trailing newlines, so a document
+    ending on a card block with no trailing newline would otherwise drop its
+    last card (issue #25).
+    """
     try:
         split = frontmatter.parse(read_file(file_path))
     except ConstructorError:
@@ -60,6 +66,9 @@ def parse_markdown_file(file_path: Path) -> Tuple[dict, str]:
 
     meta = split[0]
     body = split[1]
+
+    if body and not body.endswith("\n"):
+        body += "\n"
 
     return meta, body
 

--- a/tests/decks/sample.md
+++ b/tests/decks/sample.md
@@ -67,5 +67,3 @@ multi-lines
 
 ---
 [^uid]: dzIiDWekpW
-
-.

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,23 @@
+from app.logic.sources import File
+from app.logic.utils import parse_markdown_file
+
+
+class TestEndOfDocument:
+    @staticmethod
+    def test_card_block_at_eof_without_trailing_newline(tmp_path):
+        """A document that ends on a card block with no trailing newline
+        should still yield a parseable note with its guid intact (issue #25)."""
+        deck = tmp_path / "deck.md"
+        deck.write_text(
+            "---\ndeck: foo\n---\n"
+            "---\n\nWhat is 2+2? ::: 4\n\n---\n[^uid]: abc1234567"
+        )
+
+        meta, body = parse_markdown_file(deck)
+        assert body.endswith("\n")  # normalized at the source boundary
+
+        file = File(path=deck, meta=meta, body=body)
+        chunks = file.extract_chunks()
+
+        assert len(chunks) == 1
+        assert chunks[0].extract_note().guid == "abc1234567"


### PR DESCRIPTION
## Summary
Fixes #25. A deck document that ends on a card block with **no trailing newline** dropped its final card: the GUID footnote regex requires trailing `\n+`, so at EOF it failed to match and `extract_note()` raised `No guid found in note meta chunk`. Because `frontmatter` strips trailing whitespace from every parsed body, this affected real files — masked only by the lone `.` crutch in `sample.md`.

## Changes
- **`app/logic/utils.py`** — guarantee a newline-terminated body at the source boundary in `parse_markdown_file`, so the "body is newline-terminated" invariant holds for every consumer (not just one regex path).
- **`tests/decks/sample.md`** — drop the `.` crutch so the fixture ends exactly on a card block (regression fixture).
- **`tests/test_sources.py`** — new regression test for a document ending on a card block at EOF.

## Verification
- 8 tests pass; `black` and `bandit` clean.
- Reviewed by code-reviewer, sw-architect, and security-analyst — no critical/high findings. (Security noted only pre-existing Low ReDoS in the chunk regexes, out of scope for this fix.)