### PR TITLE
Fix _extract_images dropping images when a note has more than one (#27)

### DIFF
--- a/app/logic/sources.py
+++ b/app/logic/sources.py
@@ -268,13 +268,13 @@ class Chunk:
     def _extract_images(self) -> List[Path]:
         """Extracts image paths from note chunk."""
         html_fields = self._extract_html_fields()
-        regex = r'.*<img.*src="(.*)".*'
+        # Relies on convert_md_to_html emitting double-quoted, single-line
+        # <img> tags; revisit this pattern if the renderer changes.
+        regex = r'<img[^>]*src="([^"]*)"'
 
         relative_image_paths = []
         for field in html_fields:
-            match = re.compile(regex, re.DOTALL).findall(field)
-            if len(match) >= 1:
-                relative_image_paths = list(match)
+            relative_image_paths.extend(re.findall(regex, field))
 
         full_image_paths = [
             Path(self.file.path).parent / x for x in relative_image_paths

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -21,3 +21,28 @@ class TestEndOfDocument:
 
         assert len(chunks) == 1
         assert chunks[0].extract_note().guid == "abc1234567"
+
+
+class TestExtractImages:
+    @staticmethod
+    def _note_with_body(tmp_path, body):
+        deck = tmp_path / "deck.md"
+        deck.write_text(
+            f"---\ndeck: foo\n---\n---\n\n{body}\n\n---\n[^uid]: abc1234567\n"
+        )
+        meta, parsed = parse_markdown_file(deck)
+        chunks = File(path=deck, meta=meta, body=parsed).extract_chunks()
+        assert len(chunks) == 1
+        return chunks[0].extract_note()
+
+    def test_images_across_multiple_fields(self, tmp_path):
+        """Images in both the question and answer are all collected (#27)."""
+        note = self._note_with_body(tmp_path, "what? ![q](one.png) ::: ![a](two.png)")
+        names = [p.name for p in note.images]
+        assert names == ["one.png", "two.png"]
+
+    def test_multiple_images_in_one_field(self, tmp_path):
+        """Two images in a single field are both collected (#27)."""
+        note = self._note_with_body(tmp_path, "q ::: ![a](one.png) and ![b](two.png)")
+        names = [p.name for p in note.images]
+        assert names == ["one.png", "two.png"]


### PR DESCRIPTION
## Summary
Fixes #27. `Chunk._extract_images()` overwrote its result list on each field iteration (`relative_image_paths = list(match)`), so a note with images in both the question and answer kept only the last field's. The greedy `re.DOTALL` pattern also mis-captured multiple `<img>` tags within a single field.

## Changes
- Accumulate paths with `extend` across fields.
- Non-greedy per-tag pattern `r'<img[^>]*src="([^"]*)"'`; added a comment noting the dependency on `convert_md_to_html`'s output format.
- Regression tests (`tests/test_sources.py::TestExtractImages`): images across both fields, and two images in one field.

## Verification
- 10 tests pass; `black` and `bandit` clean.
- Reviewed by code-reviewer, sw-architect, security-analyst — no critical/high. (Architect noted a pre-existing media de-dup/basename-collision concern in `Deck.compile`, out of scope; can be a follow-up.)