### PR TITLE
Fix generate_random_string returning fewer than length chars (#30)

### DIFF
--- a/app/logic/utils.py
+++ b/app/logic/utils.py
@@ -1,8 +1,8 @@
-import base64
 import hashlib
 import logging
-import os
 import re
+import secrets
+import string
 from pathlib import Path
 from typing import List, Tuple
 
@@ -89,15 +89,9 @@ def generate_integer_hash(text: str) -> int:
 
 
 def generate_random_string(length: int = 10) -> str:
-    """
-    Generate a random string of a specified length using base64 encoding and
-    restricting characters to A-Z, a-z, and 0-9.
-    """
-    random_bytes = os.urandom(length)
-    random_base64 = base64.b64encode(random_bytes).decode("utf-8")
-    random_string = "".join(filter(str.isalnum, random_base64))[:length]
-
-    return random_string
+    """Generate a random alphanumeric string (A-Z, a-z, 0-9) of the given length."""
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(length))
 
 
 def get_url_regex_expression() -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,10 +42,9 @@ class TestGen:
 
     @staticmethod
     def test_gen_chunk_output_shape():
-        # {1,10} reflects the current (buggy) uid length contract; see #30.
         result = runner.invoke(app, ["gen", "chunk"])
         assert result.exit_code == 0
-        assert re.search(r"---\n---\n\[\^uid\]: [A-Za-z0-9]{1,10}", result.stdout)
+        assert re.search(r"---\n---\n\[\^uid\]: [A-Za-z0-9]{10}\n?$", result.stdout)
 
 
 class TestList:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,14 +22,11 @@ class TestGenerateIntegerHash:
 class TestGenerateRandomString:
     @staticmethod
     def test_length_and_alphanumeric():
-        # Asserts the current contract (<= length); the function can return
-        # fewer than `length` chars (see issue #30). Tighten to == length
-        # once that bug is fixed.
         for length in (1, 5, 10, 20):
-            for _ in range(50):
+            for _ in range(200):
                 s = generate_random_string(length)
                 assert s.isalnum()
-                assert 0 < len(s) <= length
+                assert len(s) == length
 
 
 class TestCleanStrForFilename:


### PR DESCRIPTION
## Summary
Fixes #30. `generate_random_string(length)` filtered non-alphanumerics from a base64 string and *then* truncated, so it could return fewer than `length` characters (~1/20k for `length=10`) — producing note uids that fail the `[A-Za-z0-9]{10}` match in `File.extract_chunks()`.

## Changes
- Replace with `secrets.choice` over an explicit `A-Za-z0-9` alphabet: exactly `length` uniform characters, clearer intent. Drops the now-unused `base64`/`os` imports.
- Tighten tests: `tests/test_utils.py` asserts `len == length`; `tests/test_cli.py` asserts the `gen chunk` uid matches `[A-Za-z0-9]{10}`.

## Verification
- 29 tests pass; `black` and `bandit` clean.
- Reviewed by code-reviewer, sw-architect, security-analyst — no critical/high. (Architect recommended the `secrets.choice` idiom over the initial loop; adopted.)