### PR TITLE
Search all subdirectories by default; --depth limits (#23)

### DIFF
--- a/app/cli/__init__.py
+++ b/app/cli/__init__.py
@@ -1,4 +1,6 @@
 DECK_HELP_STR = "Specify the name of the source deck"
 
 PATH_HELP_STR = "Declare the base directory to search for valid source decks"
-DEPTH_HELP_STR = "Declare the maximum search depth for valid source decks"
+DEPTH_HELP_STR = (
+    "Limit how many subdirectory levels to search (default: all subdirectories)"
+)

--- a/app/cli/build.py
+++ b/app/cli/build.py
@@ -23,7 +23,7 @@ def compile_src_decks(
     depth: Annotated[
         Optional[int],
         typer.Option(min=0, help=DEPTH_HELP_STR),
-    ] = 0,
+    ] = None,
     output: Annotated[
         Optional[Path],
         typer.Option(help="Declare the output directory to write compiled packages to"),

--- a/app/cli/list.py
+++ b/app/cli/list.py
@@ -12,7 +12,7 @@ list_app = typer.Typer()
 @list_app.command("deck")
 def list_src_decks(
     path: Annotated[Optional[Path], typer.Option(help=PATH_HELP_STR)] = Path("."),
-    depth: Annotated[Optional[int], typer.Option(min=0, help=DEPTH_HELP_STR)] = 0,
+    depth: Annotated[Optional[int], typer.Option(min=0, help=DEPTH_HELP_STR)] = None,
 ) -> None:
     """Lists valid source decks."""
 
@@ -34,7 +34,7 @@ def list_src_decks(
 def list_src_files(
     deck: Annotated[str, typer.Option(help=DECK_HELP_STR)],
     path: Annotated[Optional[Path], typer.Option(help=PATH_HELP_STR)] = Path("."),
-    depth: Annotated[Optional[int], typer.Option(min=0, help=DEPTH_HELP_STR)] = 0,
+    depth: Annotated[Optional[int], typer.Option(min=0, help=DEPTH_HELP_STR)] = None,
 ) -> None:
     """Lists source files for a deck."""
 

--- a/app/config.py
+++ b/app/config.py
@@ -4,7 +4,7 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     """Project settings"""
 
-    VERSION: str = "0.1.5"
+    VERSION: str = "0.2.0"
     DECK_TITLE_KEY: str = "deck"
     GUID_KEY: str = "uid"
     TAG_KEY: str = "tag"

--- a/app/logic/drivers.py
+++ b/app/logic/drivers.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from app.config import settings
 from app.logic.sources import Deck
@@ -13,7 +13,7 @@ from app.logic.utils import (
 def compile_deck(
     deck_name: str,
     source_search_path: Path,
-    source_search_depth: int,
+    source_search_depth: Optional[int],
     output_path: Path,
 ) -> None:
     """Compiles a single deck."""
@@ -28,7 +28,7 @@ def compile_deck(
 def compile_decks(
     deck_names: List[str],
     source_search_path: Path,
-    source_search_depth: int,
+    source_search_depth: Optional[int],
     output_path: Path,
 ) -> None:
     """Compiles a list of source decks."""
@@ -43,7 +43,7 @@ def compile_decks(
 
 def list_source_decks(
     source_search_path: Path,
-    source_search_depth: int,
+    source_search_depth: Optional[int],
 ) -> List[str]:
     """Returns list of all source deck names."""
     markdown_file_paths = search_markdown_files(
@@ -66,7 +66,7 @@ def list_source_decks(
 def list_source_files(
     deck_name: str,
     source_search_path: Path,
-    source_search_depth: int,
+    source_search_depth: Optional[int],
 ) -> List[Path]:
     """Returns a list of all source file paths for a deck."""
     deck = Deck(

--- a/app/logic/sources.py
+++ b/app/logic/sources.py
@@ -22,7 +22,7 @@ from app.logic.utils import (
 class Deck:
     name: str
     source_search_path: Path
-    source_search_depth: int
+    source_search_depth: Optional[int]
 
     def compile(self, output_path: Path) -> None:
         """Packages a deck."""

--- a/app/logic/utils.py
+++ b/app/logic/utils.py
@@ -4,29 +4,46 @@ import re
 import secrets
 import string
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import frontmatter
 from markdown import markdown
 from yaml.constructor import ConstructorError
 
 
-def search_files(extension: str, search_dir: Path, search_depth: int) -> List[Path]:
+def search_files(
+    extension: str, search_dir: Path, search_depth: Optional[int] = None
+) -> List[Path]:
     """
-    Looks for files with the given extension in
-    the given directory and its subdirectories
-    up to the specified search depth.
+    Looks for files with the given extension in the given directory and its
+    subdirectories. When ``search_depth`` is None all subdirectories are
+    searched; otherwise the search is limited to that many levels below the
+    root (depth 0 = root only).
+
+    Hidden directories (names starting with ".") and symlinked directories are
+    skipped, the latter to avoid symlink-cycle infinite recursion. Directories
+    that cannot be read are logged and skipped.
     """
 
     def search(current_dir: Path, current_depth: int) -> List[Path]:
-        if current_depth > search_depth:
+        if search_depth is not None and current_depth > search_depth:
+            return []
+
+        try:
+            items = list(current_dir.iterdir())
+        except OSError as exc:
+            logging.warning("Could not read directory %s: %s", current_dir, exc)
             return []
 
         result = []
-        for item in current_dir.iterdir():
+        for item in items:
             if item.is_file() and item.suffix == f"{extension}":
                 result.append(item)
-            elif item.is_dir():
+            elif (
+                item.is_dir()
+                and not item.is_symlink()
+                and not item.name.startswith(".")
+            ):
                 result.extend(search(item, current_depth + 1))
 
         return result
@@ -34,10 +51,11 @@ def search_files(extension: str, search_dir: Path, search_depth: int) -> List[Pa
     return search(search_dir, 0)
 
 
-def search_markdown_files(search_path: Path, search_depth: int) -> List[Path]:
-    """Get all markdown files in
-    the given directory and its subdirectories
-    up to the specified search depth.
+def search_markdown_files(
+    search_path: Path, search_depth: Optional[int] = None
+) -> List[Path]:
+    """Get all markdown files in the given directory and its subdirectories,
+    limited to ``search_depth`` levels when provided (None = unlimited).
     """
     return search_files(".md", search_path, search_depth)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ankcompiler"
 description = "A CLI tool for compiling Anki decks, defined in Markdown"
-version = "0.1.5"
+version = "0.2.0"
 authors = [
     {name = "Quinn Herden", email = "55929299+QuinnHerden@users.noreply.github.com"},
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,51 +49,34 @@ class TestGen:
 
 class TestList:
     @staticmethod
-    def test_list_deck():
-        result = runner.invoke(  # not a deep enough search
+    def test_list_deck_recurses_by_default():
+        # default: search all subdirectories of --path (deck lives in tests/decks)
+        result = runner.invoke(app, ["list", "deck", "--path", "tests"])
+        assert result.exit_code == 0
+        assert "foo" in result.stdout
+
+    @staticmethod
+    def test_list_deck_depth_limits():
+        result = runner.invoke(  # root only -> deck lives deeper, so none found
             app,
-            [
-                "list",
-                "deck",
-            ],
+            ["list", "deck", "--path", "tests", "--depth", "0"],
         )
         assert result.exit_code == 1
 
+    @staticmethod
+    def test_list_file_recurses_by_default():
         result = runner.invoke(
-            app,
-            [
-                "list",
-                "deck",
-                "--depth",
-                "2",
-            ],
+            app, ["list", "file", "--deck", "foo", "--path", "tests"]
         )
         assert result.exit_code == 0
 
     @staticmethod
-    def test_list_file():
-        result = runner.invoke(  # not a deep enough search
-            app,
-            [
-                "list",
-                "file",
-                "--deck",
-                "foo",
-            ],
-        )
-        assert result.exit_code == 1
-
+    def test_list_file_depth_limits():
         result = runner.invoke(
             app,
-            [
-                "list",
-                "file",
-                "--deck",
-                "foo",
-                "--depth",
-                "2",
-            ],
+            ["list", "file", "--deck", "foo", "--path", "tests", "--depth", "0"],
         )
+        assert result.exit_code == 1
 
 
 class TestBuild:
@@ -109,6 +92,11 @@ class TestBuild:
                 "2",
             ],
         )
+        assert result.exit_code == 0
+
+    @staticmethod
+    def test_build_one_recurses_by_default():
+        result = runner.invoke(app, ["build", "--deck", "foo", "--path", "tests"])
         assert result.exit_code == 0
 
     @staticmethod

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -69,3 +69,24 @@ class TestSearchFiles:
         assert names(0) == ["top.md"]
         assert names(1) == ["mid.md", "top.md"]
         assert names(2) == ["low.md", "mid.md", "top.md"]
+
+    def test_unlimited_depth_by_default(self, tmp_path):
+        self._make_tree(tmp_path)
+        found = sorted(p.name for p in search_files(".md", tmp_path))
+        assert found == ["low.md", "mid.md", "top.md"]
+
+    def test_hidden_directories_skipped(self, tmp_path):
+        self._make_tree(tmp_path)
+        hidden = tmp_path / ".git"
+        hidden.mkdir()
+        (hidden / "internal.md").write_text("x")
+        found = sorted(p.name for p in search_files(".md", tmp_path))
+        assert "internal.md" not in found
+
+    def test_symlink_cycle_does_not_recurse(self, tmp_path):
+        self._make_tree(tmp_path)
+        loop = tmp_path / "sub" / "loop"
+        loop.symlink_to(tmp_path, target_is_directory=True)  # points back to root
+        # must terminate (no infinite recursion) and ignore the symlinked dir
+        found = sorted(p.name for p in search_files(".md", tmp_path))
+        assert found == ["low.md", "mid.md", "top.md"]


### PR DESCRIPTION
## Summary
Closes #23. The default deck search recursed only the **root** of the given path; finding decks in subdirectories required `--depth N`. This flips the default to search **all** subdirectories, with `--depth` now *limiting* the search (default: unlimited).

## Changes
- `app/logic/utils.py` — `search_files`/`search_markdown_files` take `search_depth: Optional[int] = None`; `None` = no depth cutoff. `Optional[int]` threaded through `drivers.py` and `sources.Deck`.
- `app/cli/build.py`, `app/cli/list.py` — `--depth` default `0` → `None`; help text updated.
- **Version bump 0.1.5 → 0.2.0** (`app/config.py`, `pyproject.toml`) — this is a default-behavior change.
- Tests: recurse-by-default vs `--depth 0` limiting (`test_cli.py`); unlimited default, depth boundaries, hidden-dir skip, and symlink-cycle safety (`test_utils.py`).

## Hardening (introduced by unbounded recursion)
Review (security + architecture) flagged that removing the depth cap exposes hazards the old root-only default masked. Addressed here:
- **Skip symlinked directories** — prevents symlink-cycle infinite recursion / `RecursionError`.
- **Skip hidden (dot) directories** — so `.git`/`.venv` aren't traversed or compiled. *Note: this slightly narrows the literal "all subdirectories" — hidden dirs are excluded by convention. Easy to revisit if undesired.*
- **Tolerate unreadable directories** — log and skip instead of aborting the whole run.

## Compatibility
Behavior change: scripts relying on the old root-only default (or passing `--depth 0` to mean "everything") will now get root-only from `--depth 0` and full recursion by default. Called out via the minor version bump.

## Verification
- 35 tests pass; `black` and `bandit` clean.
- Reviewed by code-reviewer, sw-architect, security-analyst — no critical/high; their symlink/error/hidden-dir recommendations are implemented and tested.