### PR TITLE
Bump CI actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,7 +32,7 @@ jobs:
       GIST_SECRET: ${{ secrets.GIST_SECRET }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run Release Check
         shell: bash
@@ -40,7 +40,7 @@ jobs:
           bash scripts/check_release.sh
 
       - name: Setup PDM
-        uses: pdm-project/setup-pdm@v4
+        uses: pdm-project/setup-pdm@v4.5
         with:
           python-version: ${{ matrix.python-version }}
           cache: true

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -13,10 +13,10 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup PDM
-        uses: pdm-project/setup-pdm@v4
+        uses: pdm-project/setup-pdm@v4.5
         with:
           python-version: 3.12
           cache: true


### PR DESCRIPTION
## Summary
`actions/checkout@v4` and `pdm-project/setup-pdm@v4` run on the **Node 20** runtime, which GitHub is deprecating (forced to Node 24 on 2026-06-16). Verified runtimes via the GitHub API:

| Action | Was | Now | Runtime |
|---|---|---|---|
| actions/checkout | v4 (node20) | **v6** | node24 |
| pdm-project/setup-pdm | v4 → floating tag is node20 | **v4.5** | node24 |

`schneegans/dynamic-badges-action@v1.8.0` (SHA-pinned) is already on node24 — unchanged.

Applied to both `checks.yml` and `deployment.yml`. YAML validated.