### PR TITLE
Dedupe media and fail on basename collisions (#40)

### DIFF
--- a/app/logic/sources.py
+++ b/app/logic/sources.py
@@ -31,10 +31,11 @@ class Deck:
         package = GenAnkiPackage(deck)
 
         chunks = self._get_chunks()
+        images = []
         for chunk in chunks:
             note = chunk.extract_note()
 
-            package.media_files.extend(note.images)
+            images.extend(note.images)
 
             deck.add_note(
                 GenAnkiNote(
@@ -42,9 +43,40 @@ class Deck:
                 )
             )
 
+        package.media_files = self._dedupe_media(images)
+
         file_name = clean_str_for_filename(self.name)
         write_path = Path(f"{output_path}/{file_name}.apkg")
         package.write_to_file(write_path)
+
+    @staticmethod
+    def _dedupe_media(images: List[Path]) -> List[Path]:
+        """De-duplicate media paths, erroring on basename collisions.
+
+        Anki keys media by basename, so two distinct files sharing a name
+        (e.g. ``a/diagram.png`` and ``b/diagram.png``) would silently clobber
+        each other in the package. De-duplicate identical files (same resolved
+        path) and raise on a genuine basename collision.
+        """
+        by_basename: dict = {}  # basename -> resolved path
+        deduped: List[Path] = []
+
+        for image in images:
+            resolved = image.resolve()
+            existing = by_basename.get(image.name)
+
+            if existing is not None:
+                if existing == resolved:
+                    continue  # same file referenced again
+                raise ValueError(
+                    f"Media basename collision: '{image.name}' refers to both "
+                    f"{existing} and {resolved}"
+                )
+
+            by_basename[image.name] = resolved
+            deduped.append(image)
+
+        return deduped
 
     def _get_chunks(self) -> List["Chunk"]:
         """Returns list of all chunks within scope."""

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import pytest
+
+from app.logic.sources import Deck
+
+
+class TestDedupeMedia:
+    @staticmethod
+    def test_identical_paths_deduped():
+        images = [Path("a/x.png"), Path("a/x.png"), Path("a/y.png")]
+        result = Deck._dedupe_media(images)
+        assert [p.name for p in result] == ["x.png", "y.png"]
+
+    @staticmethod
+    def test_basename_collision_raises():
+        images = [Path("a/diagram.png"), Path("b/diagram.png")]
+        with pytest.raises(ValueError, match="basename collision.*diagram.png"):
+            Deck._dedupe_media(images)
+
+    @staticmethod
+    def test_distinct_names_preserved_in_order():
+        images = [Path("a/one.png"), Path("a/two.png"), Path("a/three.png")]
+        result = Deck._dedupe_media(images)
+        assert [p.name for p in result] == ["one.png", "two.png", "three.png"]
+
+    @staticmethod
+    def test_duplicate_then_collision():
+        images = [Path("a/x.png"), Path("a/x.png"), Path("b/x.png")]
+        with pytest.raises(ValueError, match="basename collision"):
+            Deck._dedupe_media(images)
+
+    @staticmethod
+    def test_distinct_basenames_same_file_both_kept(tmp_path):
+        """Two different names pointing at the same file (symlink) are both
+        kept — genanki stores media by basename, so each name is needed."""
+        real = tmp_path / "real.png"
+        real.write_bytes(b"img")
+        link = tmp_path / "alias.png"
+        link.symlink_to(real)
+        result = Deck._dedupe_media([real, link])
+        assert sorted(p.name for p in result) == ["alias.png", "real.png"]
+
+    @staticmethod
+    def test_empty():
+        assert Deck._dedupe_media([]) == []


### PR DESCRIPTION
## Summary
Fixes #40. `Deck.compile` accumulated note images and `extend`-ed `package.media_files`, so an image used by N cards was added N times, and — because Anki keys media by **basename** — two distinct files sharing a name (`a/diagram.png`, `b/diagram.png`) silently clobbered each other.

## Changes
- New `Deck._dedupe_media`: de-duplicates and collision-checks on **basename** (genanki's media key). Resolved path only distinguishes "same file referenced again" (deduped) from a genuine collision (raises `ValueError` naming both paths). Different names pointing at the same underlying file are both kept.
- `Deck.compile` now collects images then assigns the deduped list.

## Verification
- 41 tests pass (`tests/test_media.py` covers dedup, ordering, collision, interleaved duplicate+collision, and the symlink-aliased-basenames case); black/bandit clean.
- Plan + code reviewed (sw-architect, security-analyst, code-reviewer). Addressed the reviewer's HIGH: keyed dedup on basename rather than resolved path so symlink/hardlink aliases don't drop a needed basename. Missing-file validation deferred to #36 (validation).