### PR TITLE
Support MathJax/LaTeX in card content (#38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,7 @@ Run `pip install ankcompiler`
 Run `ankc --help` for usage information.
 ### Examples
 An example source deck can be found in the [test deck](https://github.com/QuinnHerden/ankcompiler/blob/main/tests/decks/sample.md)
+### Math
+Inline (`$...$`) and block (`$$...$$`) LaTeX is rendered by Anki's MathJax. Use `\$` for a literal dollar sign.
 ## Credits
 Inspiration taken from [lukesmurry](https://github.com/lukesmurray/markdown-anki-decks)

--- a/app/logic/utils.py
+++ b/app/logic/utils.py
@@ -134,7 +134,11 @@ def convert_md_to_html(md_fields: List[str]) -> List[str]:
     html_fields = []
     for field in md_fields:
         md_field = markdown(
-            field, extensions=["markdown.extensions.fenced_code", "tables"]
+            field,
+            extensions=["fenced_code", "tables", "pymdownx.arithmatex"],
+            # generic mode emits \(...\) / \[...\] (data only, no inline
+            # script), which Anki's built-in MathJax renders.
+            extension_configs={"pymdownx.arithmatex": {"generic": True}},
         )
         html_fields.append(md_field)
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:a137db26dd8a1ab2b59092c8a9d1fa9ce466293a83fd69244ad0164350f4bedb"
+content_hash = "sha256:dd29cd987174e111169e0f7f34206407c2099d6595034a913bb6b4e3393e6271"
 
 [[metadata.targets]]
 requires_python = ">=3.11"
@@ -595,6 +595,21 @@ groups = ["default", "dev"]
 files = [
     {file = "pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a"},
     {file = "pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199"},
+]
+
+[[package]]
+name = "pymdown-extensions"
+version = "10.21.3"
+requires_python = ">=3.9"
+summary = "Extension pack for Python Markdown."
+groups = ["default"]
+dependencies = [
+    "markdown>=3.6",
+    "pyyaml",
+]
+files = [
+    {file = "pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6"},
+    {file = "pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "dataclasses>=0.6",
     "python-frontmatter>=1.1.0",
     "markdown>=3.6",
+    "pymdown-extensions>=10.0",
 ]
 requires-python = ">=3.11"
 readme = "README.md"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,6 +47,34 @@ class TestConvertMdToHtml:
         assert "<p>a</p>" in out[0]
         assert "<p>b</p>" in out[1]
 
+    @staticmethod
+    def test_inline_math():
+        (out,) = convert_md_to_html([r"$E = mc^2$"])
+        assert r"\(E = mc^2\)" in out  # Anki-native MathJax delimiters
+
+    @staticmethod
+    def test_block_math():
+        (out,) = convert_md_to_html([r"$$A = \pi r^2$$"])
+        assert r"\[A = \pi r^2\]" in out
+
+    @staticmethod
+    def test_currency_not_treated_as_math():
+        (out,) = convert_md_to_html([r"it costs $5 and $10"])
+        assert "$5 and $10" in out
+        assert "arithmatex" not in out
+
+    @staticmethod
+    def test_inequality_escaped_inside_math():
+        # '<' is HTML-escaped even inside math; Anki's MathJax decodes it.
+        (out,) = convert_md_to_html([r"$x < y$"])
+        assert r"\(x &lt; y\)" in out
+
+    @staticmethod
+    def test_math_inside_table():
+        out = convert_md_to_html(["| f | val |\n|---|---|\n| $x^2$ | y |"])[0]
+        assert "<table>" in out
+        assert r"\(x^2\)" in out
+
 
 class TestSearchFiles:
     @staticmethod


### PR DESCRIPTION
## Summary
Closes #38. Cards can now use inline `$...$` and block `$$...$$` LaTeX, rendered by Anki's built-in MathJax.

## Changes
- `convert_md_to_html` enables `pymdownx.arithmatex` with `generic=True`, emitting `\(...\)` / `\[...\]` (Anki-native MathJax delimiters). Generic mode is **data-only** (no inline `<script>`) and HTML-escapes math content — the safer of arithmatex's modes.
- Added `pymdown-extensions>=10.0` dependency (lock updated; single package added).
- Tests: inline, block, digit-prefixed currency passthrough, inequality (`<`) escaping, and math inside a table. README authoring note (`\$` escapes a literal dollar).

## Verification
- 46 tests pass; black/bandit clean. Confirmed the `_extract_images` `<img>` regex is unaffected (arithmatex wraps in `<span/div class="arithmatex">`, never `<img>`).
- Reviewed by code-reviewer, security-analyst, sw-architect — no critical/high. Security confirmed generic mode adds no script surface vs inline-MathJax mode. Applied review nits (consistent short extension names; inequality-escaping test).