### PR TITLE
Add basic-reversed and type-in note types via declared [^type] (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Run `pip install ankcompiler`
 Run `ankc --help` for usage information.
 ### Examples
 An example source deck can be found in the [test deck](https://github.com/QuinnHerden/ankcompiler/blob/main/tests/decks/sample.md)
+### Note types
+- **Question/Answer** — `front ::: back` (detected automatically).
+- **Cloze** — `{{c1:: ...}}` (detected automatically).
+- **Basic-and-reversed** — `front ::: back` with `[^type]: reversed`; generates both directions.
+- **Type-in-answer** — `question ::: answer` with `[^type]: type-in`.
+
+Reversed and type-in cards share the `:::` syntax, so declare them explicitly with a `[^type]` footnote alongside `[^uid]`.
 ### Math
 Inline (`$...$`) and block (`$$...$$`) LaTeX is rendered by Anki's MathJax. Use `\$` for a literal dollar sign.
 ## Credits

--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
     DECK_TITLE_KEY: str = "deck"
     GUID_KEY: str = "uid"
     TAG_KEY: str = "tag"
+    TYPE_KEY: str = "type"
     META_TAG_KEY: str = "tags"
     MASTER_STYLESHEET: str = "_stylesheet.css"
 

--- a/app/logic/sources.py
+++ b/app/logic/sources.py
@@ -139,8 +139,10 @@ class File:
             + r" *[A-Za-z0-9]{10}\n+)"  # [^uid]: abc1234XYZ
         )
         tag_exp = rf"(?:\[\^{settings.TAG_KEY}\]: *.+?\n+)"  # [^tag]: tag_name
+        type_exp = rf"(?:\[\^{settings.TYPE_KEY}\]: *.+?\n+)"  # [^type]: reversed
 
-        meta_exp = rf"({tag_exp}*{uid_exp}?{tag_exp}*)"
+        # Footnotes (uid/tag/type) may appear in any order after the block.
+        meta_exp = rf"((?:{uid_exp}|{tag_exp}|{type_exp})*)"
 
         note_exp = r"(?:---\n\s*\n+(.(?:.|\n)+?.)\n\s*\n---\n+)"  # triple "-" delimited w/ internal newline padding
         combined_exp = rf"({note_exp}{meta_exp}?)"
@@ -191,19 +193,20 @@ class Chunk:
         if guid is None:
             raise ValueError("No guid found in note meta chunk")
 
-        model = self._extract_type().model
-        fields = self._extract_fields()
+        note_type = self._resolve_type(meta_dict)
+        html_fields = self._extract_html_fields(note_type)
+        fields = [*html_fields, self.file.get_name()]
 
         meta_tags = self.file.get_tags()
 
         tags.extend(meta_tags)
         tags = list(dict.fromkeys(tags))
 
-        images = self._extract_images()
+        images = self._extract_images(html_fields)
 
         note = Note(
             guid=guid,
-            model=model,
+            model=note_type.model,
             fields=fields,
             tags=tags,
             source=self.file,
@@ -216,11 +219,17 @@ class Chunk:
         """
         Extracts footer metadata from note chunk.
         """
-        meta_dict = {settings.GUID_KEY: None, settings.TAG_KEY: []}
+        meta_dict = {
+            settings.GUID_KEY: None,
+            settings.TAG_KEY: [],
+            settings.TYPE_KEY: None,
+        }
 
+        # Value pattern is [\w-]+ (word chars + hyphen, e.g. "type-in"); keep
+        # in sync with the footnote value patterns in File.extract_chunks.
         matches = re.findall(
-            r"(\[\^(\w+)\]: *(\w+))", self.meta
-        )  # [^example_key]: example_value
+            r"(\[\^(\w+)\]: *([\w-]+))", self.meta
+        )  # [^example_key]: example-value
 
         pairs = []
         for match in matches:
@@ -242,11 +251,33 @@ class Chunk:
         return meta_dict
 
     def _extract_type(self) -> "NoteType":
-        """Classifies note chunk into a note type."""
+        """Resolves the note type for this chunk (parsing meta on demand)."""
+        return self._resolve_type(self._extract_meta())
+
+    def _resolve_type(self, meta_dict: dict) -> "NoteType":
+        """Resolves the note type from already-parsed metadata.
+
+        If a ``[^type]`` footnote is declared it selects the type by key;
+        otherwise the type is auto-detected by matching the body against the
+        auto-detectable types (QA, Cloze). Types that share the ``:::`` field
+        syntax (reversed, type-in) must be declared explicitly to avoid
+        ambiguous auto-detection.
+        """
         types = NoteType.get_types()
+
+        declared = meta_dict.get(settings.TYPE_KEY)
+        if declared is not None:
+            declared = declared.strip().lower()
+            for type_ in types:
+                if type_.key == declared:
+                    return type_
+            valid = ", ".join(t.key for t in types)
+            raise ValueError(f"Unknown note type '{declared}'. Valid types: {valid}")
 
         matches = []
         for type_ in types:
+            if not type_.auto_detect:
+                continue
             match = re.compile(type_.regex, re.DOTALL).findall(self.body)
             if len(match) > 0:
                 matches.append(type_)
@@ -259,35 +290,22 @@ class Chunk:
 
         return matches[0]
 
-    def _extract_fields(self) -> List[str]:
-        """
-        Extracts presentation-ready fields from note chunk.
-        """
-        fields = []
-
-        html_fields = self._extract_html_fields()
-        fields.extend(html_fields)
-
-        source_file_name = self.file.get_name()
-        fields.append(source_file_name)
-
-        return fields
-
-    def _extract_html_fields(self) -> List[str]:
+    def _extract_html_fields(self, note_type: "NoteType") -> List[str]:
         """Extracts HTML fields from note chunk."""
-        md_fields = self._extract_md_fields()
+        md_fields = self._extract_md_fields(note_type)
         html_fields = convert_md_to_html(md_fields)
 
         return html_fields
 
-    def _extract_md_fields(self) -> List[str]:
+    def _extract_md_fields(self, note_type: "NoteType") -> List[str]:
         """Extracts markdown fields from note chunk."""
-        note_type = self._extract_type()
-
         matches = re.compile(note_type.regex, re.DOTALL).findall(self.body)
 
         if len(matches) != 1:
-            raise ValueError("Could not extract content from chunk")
+            raise ValueError(
+                f"Could not extract {note_type.name} fields from chunk; "
+                f"body does not match the expected syntax"
+            )
 
         if isinstance(matches[0], tuple):  # need to unpack (['…', '…'])
             md_fields = list(matches[0])
@@ -297,9 +315,8 @@ class Chunk:
 
         return md_fields
 
-    def _extract_images(self) -> List[Path]:
-        """Extracts image paths from note chunk."""
-        html_fields = self._extract_html_fields()
+    def _extract_images(self, html_fields: List[str]) -> List[Path]:
+        """Extracts image paths from already-rendered HTML fields."""
         # Relies on convert_md_to_html emitting double-quoted, single-line
         # <img> tags; revisit this pattern if the renderer changes.
         regex = r'<img[^>]*src="([^"]*)"'
@@ -327,16 +344,20 @@ class Note:
 @dataclass
 class NoteType:
     name: str
+    key: str  # value used in a [^type] footnote to select this type
     regex: str
     model: GenAnkiModel
+    auto_detect: bool = True  # whether the body can be matched without [^type]
 
     @staticmethod
     def get_types() -> List["NoteType"]:
         """Provides the master list of 'block' (note) types"""
+        qa_regex = r"(.+):::(.+)"
         return [
             NoteType(
                 name="QA",
-                regex=r"(.+):::(.+)",
+                key="qa",
+                regex=qa_regex,
                 model=GenAnkiModel(
                     model_id="1764365620",
                     name="AnkCompiler-Question_Answer",
@@ -358,6 +379,7 @@ class NoteType:
             ),
             NoteType(
                 name="Cloze",
+                key="cloze",
                 regex=r"(.*(?:\{{ *c\d+ *:: *[\s\S]+? *\}})+.*)",
                 model=GenAnkiModel(
                     model_id="1783507665",
@@ -372,6 +394,61 @@ class NoteType:
                     ],
                     css=f'@import url("{settings.MASTER_STYLESHEET}");',
                     model_type=GenAnkiModel.CLOZE,
+                ),
+            ),
+            # Shares the QA ::: field syntax; must be declared via [^type]
+            # because its body is indistinguishable from a QA card.
+            NoteType(
+                name="Basic-Reversed",
+                key="reversed",
+                regex=qa_regex,
+                auto_detect=False,
+                model=GenAnkiModel(
+                    model_id="1764365630",
+                    name="AnkCompiler-Basic-Reversed",
+                    fields=[
+                        {"name": "Front"},
+                        {"name": "Back"},
+                        {"name": "Source"},
+                    ],
+                    templates=[
+                        {
+                            "name": "Forward",
+                            "qfmt": "{{Front}}",
+                            "afmt": "{{Front}}<hr id=answer>{{Back}}",
+                        },
+                        {
+                            "name": "Reverse",
+                            "qfmt": "{{Back}}",
+                            "afmt": "{{Back}}<hr id=answer>{{Front}}",
+                        },
+                    ],
+                    css=f'@import url("{settings.MASTER_STYLESHEET}");',
+                    model_type=GenAnkiModel.FRONT_BACK,
+                ),
+            ),
+            NoteType(
+                name="Type-In",
+                key="type-in",
+                regex=qa_regex,
+                auto_detect=False,
+                model=GenAnkiModel(
+                    model_id="1764365640",
+                    name="AnkCompiler-Type-In",
+                    fields=[
+                        {"name": "Question"},
+                        {"name": "Answer"},
+                        {"name": "Source"},
+                    ],
+                    templates=[
+                        {
+                            "name": "Type-In",
+                            "qfmt": "{{Question}}<br>{{type:Answer}}",
+                            "afmt": "{{Question}}<hr id=answer>{{Answer}}",
+                        },
+                    ],
+                    css=f'@import url("{settings.MASTER_STYLESHEET}");',
+                    model_type=GenAnkiModel.FRONT_BACK,
                 ),
             ),
         ]

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -14,6 +14,49 @@ def build_note(tmp_path, body, frontmatter="deck: foo", meta="[^uid]: abc1234567
     return chunks[0].extract_note()
 
 
+class TestDeclaredNoteType:
+    def test_reversed_uses_two_templates(self, tmp_path):
+        note = build_note(
+            tmp_path,
+            "front ::: back",
+            meta="[^uid]: abc1234567\n[^type]: reversed",
+        )
+        assert note.model.name == "AnkCompiler-Basic-Reversed"
+        assert len(note.model.templates) == 2
+        assert note.fields[:2] == note.fields[:2]  # front/back rendered
+        assert "front" in note.fields[0]
+        assert "back" in note.fields[1]
+
+    def test_type_in_uses_type_template(self, tmp_path):
+        note = build_note(
+            tmp_path,
+            "capital of France ::: Paris",
+            meta="[^uid]: abc1234567\n[^type]: type-in",
+        )
+        assert note.model.name == "AnkCompiler-Type-In"
+        assert "{{type:Answer}}" in note.model.templates[0]["qfmt"]
+
+    def test_explicit_qa_type(self, tmp_path):
+        note = build_note(tmp_path, "q ::: a", meta="[^uid]: abc1234567\n[^type]: qa")
+        assert note.model.name == "AnkCompiler-Question_Answer"
+
+    def test_unknown_type_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="Unknown note type 'bogus'"):
+            build_note(tmp_path, "q ::: a", meta="[^uid]: abc1234567\n[^type]: bogus")
+
+    def test_declared_type_body_mismatch_names_type(self, tmp_path):
+        # [^type]: cloze but a ::: body -> error should name the note type.
+        with pytest.raises(ValueError, match="Cloze"):
+            build_note(
+                tmp_path, "front ::: back", meta="[^uid]: abc1234567\n[^type]: cloze"
+            )
+
+    def test_reversed_not_auto_detected_without_declaration(self, tmp_path):
+        # A plain ::: card with no [^type] is QA, never ambiguous with reversed.
+        note = build_note(tmp_path, "q ::: a")
+        assert note.model.name == "AnkCompiler-Question_Answer"
+
+
 class TestExtractType:
     @staticmethod
     def test_no_matching_type_raises():


### PR DESCRIPTION
## Summary
Closes #39. Adds **basic-and-reversed** and **type-in-answer** note types. Per the plan review, note type is now **declared** via a `[^type]` footnote rather than inferred from a per-type separator — avoiding the "separator soup" / content-collision ambiguity (especially with MathJax `<=>`-like content).

## Design
- `[^type]` footnote selects the type by key: `qa`, `cloze`, `reversed`, `type-in`.
- No `[^type]` → auto-detection over **QA and Cloze only** (unchanged behavior; existing decks keep working).
- Reversed and type-in reuse the QA `:::` field syntax, so they're `auto_detect=False` and must be declared — they can never be ambiguously auto-detected.

## Changes
- `config.py`: `TYPE_KEY="type"`.
- `File.extract_chunks`: `meta_exp` generalized to capture uid/tag/type footnotes in any order.
- `Chunk._extract_meta`: parses `[^type]`; value pattern widened `(\w+)`→`([\w-]+)` so `type-in` parses (also fixes hyphenated values; documented coupling with the splitter).
- Type resolution + HTML rendering computed **once** in `extract_note` and threaded into field/image extraction (was recomputed 3×). Field-extraction errors now name the note type.
- New genanki models: `Basic-Reversed` (Forward+Reverse templates) and `Type-In` (`{{type:Answer}}`), new stable model_ids.
- README: note-types section.

## Verification
- 52 tests pass; black/bandit clean. Backward compat confirmed (all prior QA/Cloze/tag tests pass unchanged).
- Reviewed by code-reviewer, sw-architect, security-analyst. Addressed the HIGH (declared-type-but-mismatched-body now errors with the type name + a regression test) and the recompute fan-out (resolve-once refactor). Security: no findings.