### PR TITLE
Add ankc check validation with file/line diagnostics (#36)

### DIFF
--- a/app/cli/build.py
+++ b/app/cli/build.py
@@ -4,9 +4,29 @@ from typing import Annotated, Optional
 import typer
 
 from app.cli import DEPTH_HELP_STR, PATH_HELP_STR
-from app.logic.drivers import compile_deck, compile_decks, list_source_decks
+from app.logic.drivers import (
+    compile_deck,
+    compile_decks,
+    list_source_decks,
+    validate_deck_files,
+)
+from app.logic.validation import format_findings
 
 build_app = typer.Typer()
+
+
+def _abort_on_validation_errors(deck_names, search_path, search_depth) -> None:
+    """Validate before compiling so problems surface with file/line context
+    instead of an opaque mid-compile traceback."""
+    findings = validate_deck_files(
+        deck_names=deck_names,
+        source_search_path=search_path,
+        source_search_depth=search_depth,
+    )
+    if findings:
+        typer.echo(format_findings(findings))
+    if any(f.level == "error" for f in findings):
+        raise typer.Exit(1)
 
 
 @build_app.callback(invoke_without_command=True)
@@ -40,6 +60,7 @@ def compile_src_decks(
     )
 
     if all_ is False and deck in source_names:
+        _abort_on_validation_errors([deck], search_path, search_depth)
         compile_deck(
             deck_name=deck,
             source_search_path=search_path,
@@ -48,6 +69,7 @@ def compile_src_decks(
         )
 
     elif all_ is True:
+        _abort_on_validation_errors(source_names, search_path, search_depth)
         compile_decks(
             deck_names=source_names,
             source_search_path=search_path,

--- a/app/cli/check.py
+++ b/app/cli/check.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+from typing import Annotated, List, Optional
+
+import typer
+
+from app.cli import DEPTH_HELP_STR, PATH_HELP_STR
+from app.logic.drivers import list_source_decks, validate_deck_files
+from app.logic.validation import findings_to_dicts, format_findings
+
+check_app = typer.Typer()
+
+
+@check_app.callback(invoke_without_command=True)
+def check_src_decks(
+    all_: Annotated[
+        Optional[bool],
+        typer.Option("--all", help="Check every deck"),
+    ] = False,
+    deck: Annotated[Optional[str], typer.Option(help="Check an explicit deck")] = None,
+    path: Annotated[Optional[Path], typer.Option(help=PATH_HELP_STR)] = Path("."),
+    depth: Annotated[Optional[int], typer.Option(min=0, help=DEPTH_HELP_STR)] = None,
+    format_: Annotated[
+        str,
+        typer.Option("--format", help="Output format: text or json"),
+    ] = "text",
+) -> None:
+    """Validates deck source files without compiling them."""
+
+    if all_:
+        deck_names: List[str] = list_source_decks(
+            source_search_path=path, source_search_depth=depth
+        )
+    elif deck is not None:
+        deck_names = [deck]
+    else:
+        typer.echo("Not a valid source selection.")
+        raise typer.Exit(1)
+
+    findings = validate_deck_files(
+        deck_names=deck_names,
+        source_search_path=path,
+        source_search_depth=depth,
+    )
+
+    if format_ == "json":
+        typer.echo(json.dumps(findings_to_dicts(findings), indent=2))
+    else:
+        typer.echo(format_findings(findings))
+
+    if any(finding.level == "error" for finding in findings):
+        raise typer.Exit(1)

--- a/app/cli/entry.py
+++ b/app/cli/entry.py
@@ -3,12 +3,14 @@ from typing import Optional
 import typer
 
 from app.cli.build import build_app
+from app.cli.check import check_app
 from app.cli.gen import gen_app
 from app.cli.list import list_app
 from app.config import settings
 
 app = typer.Typer()
 app.add_typer(build_app, name="build")
+app.add_typer(check_app, name="check")
 app.add_typer(list_app, name="list")
 app.add_typer(gen_app, name="gen")
 

--- a/app/logic/drivers.py
+++ b/app/logic/drivers.py
@@ -8,6 +8,7 @@ from app.logic.utils import (
     parse_markdown_file,
     search_markdown_files,
 )
+from app.logic.validation import Finding, validate_files
 
 
 def compile_deck(
@@ -77,6 +78,25 @@ def list_source_files(
     paths = deck.get_source_file_paths()
 
     return paths
+
+
+def validate_deck_files(
+    deck_names: List[str],
+    source_search_path: Path,
+    source_search_depth: Optional[int],
+) -> List[Finding]:
+    """Validates all source files belonging to the given decks."""
+    file_paths: List[Path] = []
+    for deck_name in deck_names:
+        file_paths.extend(
+            list_source_files(
+                deck_name=deck_name,
+                source_search_path=source_search_path,
+                source_search_depth=source_search_depth,
+            )
+        )
+
+    return validate_files(file_paths)
 
 
 def generate_chunk() -> str:

--- a/app/logic/sources.py
+++ b/app/logic/sources.py
@@ -17,6 +17,16 @@ from app.logic.utils import (
     search_markdown_files,
 )
 
+# Shared note-block grammar — single source of truth for the chunk parser
+# (File.extract_chunks) and the validator (app.logic.validation). Footnotes
+# (uid/tag/type) may follow a block in any order.
+GUID_FOOTNOTE = rf"(?:\[\^{settings.GUID_KEY}\]: *[A-Za-z0-9]{{10}}\n+)"
+TAG_FOOTNOTE = rf"(?:\[\^{settings.TAG_KEY}\]: *.+?\n+)"
+TYPE_FOOTNOTE = rf"(?:\[\^{settings.TYPE_KEY}\]: *.+?\n+)"
+# Block body between the "---" delimiters. A single character class (rather
+# than an ambiguous (.|\n) alternation) to avoid catastrophic backtracking.
+NOTE_BODY = r"[\s\S]+?"
+
 
 @dataclass
 class Deck:
@@ -134,17 +144,8 @@ class File:
     def extract_chunks(self) -> List["Chunk"]:
         """Splits markdown file into list of its note chunks."""
 
-        uid_exp = (
-            rf"(?:\[\^{settings.GUID_KEY}\]:"
-            + r" *[A-Za-z0-9]{10}\n+)"  # [^uid]: abc1234XYZ
-        )
-        tag_exp = rf"(?:\[\^{settings.TAG_KEY}\]: *.+?\n+)"  # [^tag]: tag_name
-        type_exp = rf"(?:\[\^{settings.TYPE_KEY}\]: *.+?\n+)"  # [^type]: reversed
-
-        # Footnotes (uid/tag/type) may appear in any order after the block.
-        meta_exp = rf"((?:{uid_exp}|{tag_exp}|{type_exp})*)"
-
-        note_exp = r"(?:---\n\s*\n+(.(?:.|\n)+?.)\n\s*\n---\n+)"  # triple "-" delimited w/ internal newline padding
+        meta_exp = rf"((?:{GUID_FOOTNOTE}|{TAG_FOOTNOTE}|{TYPE_FOOTNOTE})*)"
+        note_exp = rf"(?:---\n\s*\n+({NOTE_BODY})\n\s*\n---\n+)"  # triple "-" delimited
         combined_exp = rf"({note_exp}{meta_exp}?)"
 
         card_matches = re.findall(combined_exp, self.body)

--- a/app/logic/validation.py
+++ b/app/logic/validation.py
@@ -1,0 +1,183 @@
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from app.config import settings
+from app.logic.sources import (
+    GUID_FOOTNOTE,
+    NOTE_BODY,
+    TAG_FOOTNOTE,
+    TYPE_FOOTNOTE,
+    Chunk,
+    File,
+)
+from app.logic.utils import parse_markdown_file, read_file
+
+# Same block grammar as File.extract_chunks (shared sub-patterns), but with
+# named groups and finditer so we can report line numbers.
+_NOTE = rf"(?:---\n\s*\n+(?P<body>{NOTE_BODY})\n\s*\n---\n+)"
+_META = rf"(?P<meta>(?:{GUID_FOOTNOTE}|{TAG_FOOTNOTE}|{TYPE_FOOTNOTE})*)"
+_BLOCK_RE = re.compile(_NOTE + _META)
+
+# Anything that looks like a card opener: a "---" line followed by a blank line.
+_OPENER_RE = re.compile(r"(?m)^---\n\s*\n")
+
+
+@dataclass
+class Finding:
+    file: Path
+    line: Optional[int]
+    level: str  # "error" | "warning"
+    message: str
+
+    def format(self) -> str:
+        loc = f"{self.file}:{self.line}" if self.line else str(self.file)
+        return f"{loc}: {self.level}: {self.message}"
+
+
+def _frontmatter_end(raw: str) -> int:
+    """Offset in ``raw`` where the post-frontmatter body begins (0 if none)."""
+    if raw.startswith("---"):
+        match = re.match(r"---\n.*?\n---\n", raw, re.DOTALL)
+        if match:
+            return match.end()
+    return 0
+
+
+def _line_at(raw: str, offset: int) -> int:
+    """1-based line number of ``offset`` within ``raw``."""
+    return raw.count("\n", 0, offset) + 1
+
+
+def validate_files(file_paths: List[Path]) -> List[Finding]:
+    """Validates the given source files, returning all findings (deck-wide:
+    duplicate uids are detected across the whole set)."""
+    findings: List[Finding] = []
+    seen_uids: Dict[str, Tuple[Path, int]] = {}
+
+    for path in file_paths:
+        findings.extend(_validate_file(path, seen_uids))
+
+    return findings
+
+
+def _validate_file(path: Path, seen_uids: Dict[str, Tuple[Path, int]]) -> List[Finding]:
+    findings: List[Finding] = []
+    raw = read_file(path)
+    meta, _ = parse_markdown_file(path)
+
+    if meta.get(settings.DECK_TITLE_KEY) is None:
+        findings.append(
+            Finding(path, 1, "error", "frontmatter is missing a 'deck' key")
+        )
+
+    body_start = _frontmatter_end(raw)
+    body = raw[body_start:]
+    # Match parse_markdown_file's trailing-newline normalization (#25) so a
+    # document ending on a card block isn't seen as missing its footnotes.
+    if body and not body.endswith("\n"):
+        body += "\n"
+    file_obj = File(path=path, meta=meta, body=body)
+
+    matched_spans: List[Tuple[int, int]] = []
+    for match in _BLOCK_RE.finditer(body):
+        matched_spans.append((match.start(), match.end()))
+        line = _line_at(raw, body_start + match.start())
+        chunk = Chunk(body=match.group("body"), meta=match.group("meta"), file=file_obj)
+        findings.extend(_validate_chunk(chunk, path, line, seen_uids))
+
+    findings.extend(_check_unparsed_openers(body, body_start, raw, matched_spans, path))
+
+    return findings
+
+
+def _validate_chunk(
+    chunk: Chunk, path: Path, line: int, seen_uids: Dict[str, Tuple[Path, int]]
+) -> List[Finding]:
+    findings: List[Finding] = []
+    meta = chunk._extract_meta()
+
+    uid = meta.get(settings.GUID_KEY)
+    if uid is None:
+        snippet = chunk.body.strip().splitlines()[0][:50]
+        findings.append(
+            Finding(path, line, "error", f'card block missing uid — "{snippet}"')
+        )
+    elif uid in seen_uids:
+        prev_file, prev_line = seen_uids[uid]
+        findings.append(
+            Finding(
+                path,
+                line,
+                "error",
+                f"duplicate uid '{uid}' (first seen at {prev_file}:{prev_line})",
+            )
+        )
+    else:
+        seen_uids[uid] = (path, line)
+
+    # Type resolution + field extraction reuse the production logic; surface
+    # their errors as findings with location instead of aborting.
+    try:
+        note_type = chunk._resolve_type(meta)
+        chunk._extract_md_fields(note_type)
+    except ValueError as exc:
+        findings.append(Finding(path, line, "error", str(exc)))
+
+    return findings
+
+
+def _check_unparsed_openers(
+    body: str,
+    body_start: int,
+    raw: str,
+    matched_spans: List[Tuple[int, int]],
+    path: Path,
+) -> List[Finding]:
+    """Flags card-like openers that no well-formed block consumed."""
+    findings: List[Finding] = []
+    for opener in _OPENER_RE.finditer(body):
+        inside = any(start <= opener.start() < end for start, end in matched_spans)
+        if not inside:
+            line = _line_at(raw, body_start + opener.start())
+            # Heuristic (a stray "---" in prose can trip it), so warn rather
+            # than error — this must not block an otherwise valid build.
+            findings.append(
+                Finding(
+                    path,
+                    line,
+                    "warning",
+                    "possibly malformed or unterminated card block",
+                )
+            )
+    return findings
+
+
+def format_findings(findings: List[Finding]) -> str:
+    """Renders findings as compiler-style lines plus a summary footer."""
+    lines = [f.format() for f in findings]
+    errors = sum(1 for f in findings if f.level == "error")
+    warnings = sum(1 for f in findings if f.level == "warning")
+    files = len({f.file for f in findings})
+
+    if not findings:
+        lines.append("no problems found")
+    else:
+        summary = f"{errors} error(s), {warnings} warning(s) across {files} file(s)"
+        lines.append(summary)
+
+    return "\n".join(lines)
+
+
+def findings_to_dicts(findings: List[Finding]) -> List[dict]:
+    """Machine-readable form of findings (for --format json)."""
+    return [
+        {
+            "file": str(f.file),
+            "line": f.line,
+            "level": f.level,
+            "message": f.message,
+        }
+        for f in findings
+    ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,6 +79,20 @@ class TestList:
         assert result.exit_code == 1
 
 
+class TestCheck:
+    @staticmethod
+    def test_check_clean_deck():
+        result = runner.invoke(app, ["check", "--deck", "foo", "--path", "tests"])
+        assert result.exit_code == 0
+        assert "no problems found" in result.stdout
+
+    @staticmethod
+    def test_check_invalid_selection():
+        result = runner.invoke(app, ["check"])  # no --deck and no --all
+        assert result.exit_code == 1
+        assert "Not a valid source selection." in result.stdout
+
+
 class TestBuild:
     @staticmethod
     def test_build_one():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,94 @@
+from app.logic.validation import (
+    findings_to_dicts,
+    format_findings,
+    validate_files,
+)
+
+
+def write_deck(tmp_path, body, name="d.md"):
+    path = tmp_path / name
+    path.write_text(body)
+    return path
+
+
+class TestValidateFiles:
+    def test_clean_deck_has_no_findings(self, tmp_path):
+        path = write_deck(
+            tmp_path,
+            "---\ndeck: foo\n---\n---\n\nq ::: a\n\n---\n[^uid]: abc1234567\n",
+        )
+        assert validate_files([path]) == []
+
+    def test_missing_uid(self, tmp_path):
+        path = write_deck(tmp_path, "---\ndeck: foo\n---\n---\n\nq ::: a\n\n---\n")
+        findings = validate_files([path])
+        assert any("missing uid" in f.message for f in findings)
+
+    def test_missing_deck_frontmatter(self, tmp_path):
+        path = write_deck(tmp_path, "---\ntags:\n  - t\n---\n")
+        findings = validate_files([path])
+        assert any(
+            "missing a 'deck' key" in f.message and f.line == 1 for f in findings
+        )
+
+    def test_duplicate_uid_cites_first_location(self, tmp_path):
+        body = (
+            "---\ndeck: foo\n---\n"
+            "---\n\nq1 ::: a1\n\n---\n[^uid]: abc1234567\n\n"
+            "---\n\nq2 ::: a2\n\n---\n[^uid]: abc1234567\n"
+        )
+        path = write_deck(tmp_path, body)
+        findings = validate_files([path])
+        dupes = [f for f in findings if "duplicate uid" in f.message]
+        assert len(dupes) == 1
+        assert "first seen at" in dupes[0].message
+
+    def test_duplicate_uid_across_files(self, tmp_path):
+        a = write_deck(
+            tmp_path,
+            "---\ndeck: foo\n---\n---\n\nq ::: a\n\n---\n[^uid]: abc1234567\n",
+            name="a.md",
+        )
+        b = write_deck(
+            tmp_path,
+            "---\ndeck: foo\n---\n---\n\nq ::: b\n\n---\n[^uid]: abc1234567\n",
+            name="b.md",
+        )
+        findings = validate_files([a, b])
+        assert any("duplicate uid" in f.message for f in findings)
+
+    def test_unknown_declared_type(self, tmp_path):
+        path = write_deck(
+            tmp_path,
+            "---\ndeck: foo\n---\n---\n\nq ::: a\n\n---\n"
+            "[^uid]: abc1234567\n[^type]: bogus\n",
+        )
+        findings = validate_files([path])
+        assert any("Unknown note type 'bogus'" in f.message for f in findings)
+
+    def test_malformed_unterminated_block(self, tmp_path):
+        # opener with no closing delimiter
+        path = write_deck(tmp_path, "---\ndeck: foo\n---\n---\n\nq ::: a\n")
+        findings = validate_files([path])
+        assert any("malformed or unterminated" in f.message for f in findings)
+
+    def test_finding_reports_line_number(self, tmp_path):
+        path = write_deck(tmp_path, "---\ndeck: foo\n---\n---\n\nq ::: a\n\n---\n")
+        findings = validate_files([path])
+        missing = next(f for f in findings if "missing uid" in f.message)
+        assert missing.line == 4  # the card block's opening delimiter
+
+
+class TestFormatting:
+    def test_format_no_findings(self):
+        assert format_findings([]) == "no problems found"
+
+    def test_format_and_json(self, tmp_path):
+        path = write_deck(tmp_path, "---\ndeck: foo\n---\n---\n\nq ::: a\n\n---\n")
+        findings = validate_files([path])
+        text = format_findings(findings)
+        assert "error:" in text
+        assert "error(s)" in text  # summary footer
+        dicts = findings_to_dicts(findings)
+        assert dicts[0]["level"] == "error"
+        assert dicts[0]["file"] == str(path)


### PR DESCRIPTION
## Summary
Closes #36. Adds `ankc check`, which validates deck source files **without compiling** and reports problems with `file:line` context. `build` now validates first and aborts with the same formatted findings instead of an opaque mid-compile traceback.

## Checks
- card block missing `[^uid]`
- duplicate uid (deck-wide; cites the first location)
- unknown / ambiguous / no note type; body not matching a declared `[^type]`
- frontmatter missing `deck`
- heuristic **warning** for a malformed/unterminated block

## Output
Compiler-style `path:line: level: message` + a summary footer; `--format json` for tooling. Errors exit 1; warnings don't.

## Design / review responses
- **New `app/logic/validation.py`** collects findings (doesn't abort), reusing `Chunk`'s meta/type/field logic so error messages match production.
- **Single-sourced grammar** — footnote + body sub-patterns now live once in `sources.py` (`GUID_FOOTNOTE`/`TAG_FOOTNOTE`/`TYPE_FOOTNOTE`/`NOTE_BODY`), imported by both the parser and validator, so they can't drift (review finding).
- **ReDoS fix** — replaced the ambiguous `(.(?:.|\n)+?.)` body pattern with `[\s\S]+?` (single source, fixes both parser and validator). Verified: 200 KB unterminated block validates in ~4 ms instead of hanging.
- **Malformed-block heuristic is a warning**, not an error, so a stray `---` in prose can't block a valid `build` (review's hardest flag). `build` surfaces warnings but only aborts on errors.
- Line numbers via `re.finditer` offsets, with body normalized for the #25 EOF case.

## Verification
- 64 tests pass (`tests/test_validation.py`, `tests/test_cli.py::TestCheck`); black/flake8/bandit clean.
- Reviewed by code-reviewer, sw-architect, security-analyst. Addressed the regex-duplication, ReDoS (Medium), and false-positive-aborts-build concerns. Follow-up tracked: promoting `Chunk`'s validation methods to a public API (currently the validator calls private methods).