### PR TITLE
Add ankc uid to stamp missing note uids (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ A CLI tool for compiling Anki decks, defined in Markdown.
 Run `pip install ankcompiler`
 ## Usage
 Run `ankc --help` for usage information.
+
+Key commands:
+- `ankc build` — compile decks into `.apkg` packages.
+- `ankc check` — validate decks without compiling; reports problems with `file:line` (`--format json` available).
+- `ankc uid` — insert a `[^uid]` footnote into any card block missing one (idempotent; `--check` for a dry run). Refuses to rewrite files with uncommitted git changes unless `--force`.
 ### Examples
 An example source deck can be found in the [test deck](https://github.com/QuinnHerden/ankcompiler/blob/main/tests/decks/sample.md)
 ### Note types

--- a/app/cli/entry.py
+++ b/app/cli/entry.py
@@ -6,6 +6,7 @@ from app.cli.build import build_app
 from app.cli.check import check_app
 from app.cli.gen import gen_app
 from app.cli.list import list_app
+from app.cli.uid import uid_app
 from app.config import settings
 
 app = typer.Typer()
@@ -13,6 +14,7 @@ app.add_typer(build_app, name="build")
 app.add_typer(check_app, name="check")
 app.add_typer(list_app, name="list")
 app.add_typer(gen_app, name="gen")
+app.add_typer(uid_app, name="uid")
 
 
 @app.callback(invoke_without_command=True)

--- a/app/cli/uid.py
+++ b/app/cli/uid.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+from typing import Annotated, Optional
+
+import typer
+
+from app.cli import DEPTH_HELP_STR, PATH_HELP_STR
+from app.logic.drivers import dirty_source_files, stamp_source_files
+
+uid_app = typer.Typer()
+
+
+@uid_app.callback(invoke_without_command=True)
+def stamp_uids(
+    path: Annotated[Optional[Path], typer.Option(help=PATH_HELP_STR)] = Path("."),
+    depth: Annotated[Optional[int], typer.Option(min=0, help=DEPTH_HELP_STR)] = None,
+    check: Annotated[
+        bool,
+        typer.Option("--check", help="Report what would be stamped; write nothing"),
+    ] = False,
+    force: Annotated[
+        bool,
+        typer.Option("--force", help="Stamp even if files have uncommitted changes"),
+    ] = False,
+) -> None:
+    """Inserts a [^uid] footnote into any card block that lacks one."""
+
+    # Refuse to rewrite files with uncommitted changes so there's always a
+    # clean git checkpoint to revert to. --check writes nothing; --force opts out.
+    if not check and not force:
+        dirty = dirty_source_files(source_search_path=path, source_search_depth=depth)
+        if dirty:
+            typer.echo("Refusing to stamp files with uncommitted changes:")
+            for dirty_path in dirty:
+                typer.echo(f"  {dirty_path}")
+            typer.echo("Commit or stash them first, or pass --force.")
+            raise typer.Exit(1)
+
+    results = stamp_source_files(
+        source_search_path=path, source_search_depth=depth, dry_run=check
+    )
+
+    total = 0
+    for result in results:
+        if result.stamped_lines:
+            count = len(result.stamped_lines)
+            total += count
+            verb = "would stamp" if check else "stamped"
+            lines = ", ".join(str(line) for line in result.stamped_lines)
+            typer.echo(f"{result.file}: {verb} {count} uid(s) at line(s) {lines}")
+
+    if total == 0:
+        typer.echo("nothing to stamp — all card blocks have uids")
+    else:
+        typer.echo(f"{total} uid(s) {'would be ' if check else ''}added")
+
+    if check and total > 0:
+        raise typer.Exit(1)

--- a/app/logic/drivers.py
+++ b/app/logic/drivers.py
@@ -8,6 +8,7 @@ from app.logic.utils import (
     parse_markdown_file,
     search_markdown_files,
 )
+from app.logic.stamping import StampResult, file_is_dirty, stamp_file
 from app.logic.validation import Finding, validate_files
 
 
@@ -97,6 +98,32 @@ def validate_deck_files(
         )
 
     return validate_files(file_paths)
+
+
+def stamp_source_files(
+    source_search_path: Path,
+    source_search_depth: Optional[int],
+    dry_run: bool,
+) -> List[StampResult]:
+    """Stamps missing uids across all markdown files under the search path."""
+    files = search_markdown_files(
+        search_path=source_search_path, search_depth=source_search_depth
+    )
+    return [
+        stamp_file(path=path, search_root=source_search_path, dry_run=dry_run)
+        for path in files
+    ]
+
+
+def dirty_source_files(
+    source_search_path: Path,
+    source_search_depth: Optional[int],
+) -> List[Path]:
+    """Returns markdown source files with uncommitted git changes."""
+    files = search_markdown_files(
+        search_path=source_search_path, search_depth=source_search_depth
+    )
+    return [path for path in files if file_is_dirty(path)]
 
 
 def generate_chunk() -> str:

--- a/app/logic/stamping.py
+++ b/app/logic/stamping.py
@@ -1,0 +1,140 @@
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from app.config import settings
+from app.logic.sources import NOTE_BODY
+from app.logic.utils import (
+    frontmatter_end_offset,
+    generate_random_string,
+    line_at,
+    read_file,
+)
+
+# A card block whose closing "---" is followed by a newline. We deliberately
+# do not reuse the combined chunk regex: stamping operates on raw file text
+# (frontmatter intact) and only needs the block boundary, not the metadata.
+_BLOCK_RE = re.compile(rf"---\n\s*\n+{NOTE_BODY}\n\s*\n---\n")
+# Contiguous footnote lines immediately following a block.
+_FOOTNOTES_RE = re.compile(r"(?:\[\^\w+\]: *.+?\n)*")
+_UID_RE = re.compile(rf"\[\^{settings.GUID_KEY}\]:")
+
+
+@dataclass
+class StampResult:
+    file: Path
+    stamped_lines: List[int] = field(default_factory=list)
+    skipped_reason: str = ""
+
+
+def stamp_text(raw: str) -> Tuple[str, List[int]]:
+    """Inserts a ``[^uid]`` footnote after every card block that lacks one.
+
+    Returns the new text and the 1-based line numbers of the inserted
+    footnotes. Pure and idempotent: blocks that already have a uid are left
+    untouched, and a file needing no stamps is returned byte-for-byte.
+    """
+    # Normalize a trailing newline for matching (mirrors parse_markdown_file,
+    # #25) so a block ending the file without one is still seen. The original
+    # is returned unchanged when nothing is stamped, so clean files are intact.
+    work = raw if raw.endswith("\n") else raw + "\n"
+    body_start = frontmatter_end_offset(work)
+    result = work[:body_start]
+    cursor = body_start
+    stamped_lines: List[int] = []
+
+    for match in _BLOCK_RE.finditer(work, body_start):
+        result += work[cursor : match.end()]
+        cursor = match.end()
+
+        following = _FOOTNOTES_RE.match(work, cursor)
+        footnotes = following.group(0) if following else ""
+
+        if not _UID_RE.search(footnotes):
+            uid = generate_random_string(length=10)
+            result += f"[^{settings.GUID_KEY}]: {uid}\n"
+            stamped_lines.append(line_at(work, cursor))  # the inserted footnote
+
+    result += work[cursor:]
+
+    if not stamped_lines:
+        return raw, []
+    return result, stamped_lines
+
+
+def stamp_file(path: Path, search_root: Path, dry_run: bool) -> StampResult:
+    """Stamps a single file, writing atomically. Skips symlinks and any path
+    that resolves outside ``search_root``."""
+    if path.is_symlink():
+        return StampResult(path, skipped_reason="symlink")
+
+    resolved = path.resolve()
+    if not resolved.is_relative_to(search_root.resolve()):
+        return StampResult(path, skipped_reason="outside search path")
+
+    # read_file translates CRLF -> LF; rewriting such a file would convert
+    # every line ending, not just the stamped lines. Skip rather than mangle.
+    if b"\r\n" in path.read_bytes():
+        return StampResult(path, skipped_reason="CRLF line endings not supported")
+
+    raw = read_file(path)
+    new_text, stamped_lines = stamp_text(raw)
+
+    if not stamped_lines:
+        return StampResult(path)
+
+    # Post-condition: a second pass must be a no-op (every block now has a uid).
+    _, again = stamp_text(new_text)
+    if again:
+        raise RuntimeError(f"stamping {path} did not converge; aborting write")
+
+    if not dry_run:
+        _atomic_write(path, raw, new_text)
+
+    return StampResult(path, stamped_lines=stamped_lines)
+
+
+def file_is_dirty(path: Path) -> Optional[bool]:
+    """Returns True if ``path`` has uncommitted git changes, False if clean,
+    or None if git is unavailable or the file isn't in a git repository."""
+    try:
+        proc = subprocess.run(
+            ["git", "status", "--porcelain", "--", str(path)],
+            capture_output=True,
+            text=True,
+            cwd=path.parent,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+
+    if proc.returncode != 0:
+        return None
+
+    return bool(proc.stdout.strip())
+
+
+def _atomic_write(path: Path, original: str, new_text: str) -> None:
+    """Writes ``new_text`` to ``path`` via a temp file + atomic rename,
+    preserving the file mode and line endings. Aborts if the file changed
+    on disk since it was read."""
+    if read_file(path) != original:
+        raise RuntimeError(f"{path} changed on disk during stamping; aborting write")
+
+    directory = path.parent
+    fd, tmp_name = tempfile.mkstemp(dir=directory, suffix=".ankc-tmp")
+    tmp_path = Path(tmp_name)
+    try:
+        # newline="" writes without translation; CRLF files are rejected
+        # upstream, so the text is LF and is written verbatim.
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as handle:
+            handle.write(new_text)
+        shutil.copystat(path, tmp_path)
+        os.replace(tmp_path, path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise

--- a/app/logic/utils.py
+++ b/app/logic/utils.py
@@ -91,6 +91,20 @@ def parse_markdown_file(file_path: Path) -> Tuple[dict, str]:
     return meta, body
 
 
+def frontmatter_end_offset(raw: str) -> int:
+    """Offset in ``raw`` where the post-frontmatter body begins (0 if none)."""
+    if raw.startswith("---"):
+        match = re.match(r"---\n.*?\n---\n", raw, re.DOTALL)
+        if match:
+            return match.end()
+    return 0
+
+
+def line_at(raw: str, offset: int) -> int:
+    """1-based line number of ``offset`` within ``raw``."""
+    return raw.count("\n", 0, offset) + 1
+
+
 def generate_integer_hash(text: str) -> int:
     """Generate an integer hash value for the given input string."""
     sha256_hash = hashlib.sha256(text.encode("utf-8")).hexdigest()

--- a/app/logic/validation.py
+++ b/app/logic/validation.py
@@ -12,7 +12,12 @@ from app.logic.sources import (
     Chunk,
     File,
 )
-from app.logic.utils import parse_markdown_file, read_file
+from app.logic.utils import (
+    frontmatter_end_offset,
+    line_at,
+    parse_markdown_file,
+    read_file,
+)
 
 # Same block grammar as File.extract_chunks (shared sub-patterns), but with
 # named groups and finditer so we can report line numbers.
@@ -34,20 +39,6 @@ class Finding:
     def format(self) -> str:
         loc = f"{self.file}:{self.line}" if self.line else str(self.file)
         return f"{loc}: {self.level}: {self.message}"
-
-
-def _frontmatter_end(raw: str) -> int:
-    """Offset in ``raw`` where the post-frontmatter body begins (0 if none)."""
-    if raw.startswith("---"):
-        match = re.match(r"---\n.*?\n---\n", raw, re.DOTALL)
-        if match:
-            return match.end()
-    return 0
-
-
-def _line_at(raw: str, offset: int) -> int:
-    """1-based line number of ``offset`` within ``raw``."""
-    return raw.count("\n", 0, offset) + 1
 
 
 def validate_files(file_paths: List[Path]) -> List[Finding]:
@@ -72,7 +63,7 @@ def _validate_file(path: Path, seen_uids: Dict[str, Tuple[Path, int]]) -> List[F
             Finding(path, 1, "error", "frontmatter is missing a 'deck' key")
         )
 
-    body_start = _frontmatter_end(raw)
+    body_start = frontmatter_end_offset(raw)
     body = raw[body_start:]
     # Match parse_markdown_file's trailing-newline normalization (#25) so a
     # document ending on a card block isn't seen as missing its footnotes.
@@ -83,7 +74,7 @@ def _validate_file(path: Path, seen_uids: Dict[str, Tuple[Path, int]]) -> List[F
     matched_spans: List[Tuple[int, int]] = []
     for match in _BLOCK_RE.finditer(body):
         matched_spans.append((match.start(), match.end()))
-        line = _line_at(raw, body_start + match.start())
+        line = line_at(raw, body_start + match.start())
         chunk = Chunk(body=match.group("body"), meta=match.group("meta"), file=file_obj)
         findings.extend(_validate_chunk(chunk, path, line, seen_uids))
 
@@ -140,7 +131,7 @@ def _check_unparsed_openers(
     for opener in _OPENER_RE.finditer(body):
         inside = any(start <= opener.start() < end for start, end in matched_spans)
         if not inside:
-            line = _line_at(raw, body_start + opener.start())
+            line = line_at(raw, body_start + opener.start())
             # Heuristic (a stray "---" in prose can trip it), so warn rather
             # than error — this must not block an otherwise valid build.
             findings.append(

--- a/tests/test_stamping.py
+++ b/tests/test_stamping.py
@@ -1,0 +1,134 @@
+import re
+import subprocess
+
+from app.logic.stamping import stamp_file, stamp_text
+
+DECK = (
+    "---\ndeck: foo\n---\n"
+    "---\n\nq1 ::: a1\n\n---\n[^uid]: abc1234567\n\n"  # already has uid
+    "---\n\nq2 ::: a2\n\n---\n[^tag]: x\n\n"  # tag only, needs uid
+    "---\n\nq3 ::: a3\n\n---\n"  # no footnotes, needs uid
+)
+
+_UID_LINE = re.compile(r"^\[\^uid\]: [A-Za-z0-9]{10}$", re.MULTILINE)
+
+
+class TestStampText:
+    def test_stamps_only_blocks_without_uid(self):
+        new_text, lines = stamp_text(DECK)
+        assert len(lines) == 2
+        assert len(_UID_LINE.findall(new_text)) == 3  # 1 existing + 2 added
+
+    def test_existing_uid_untouched(self):
+        new_text, _ = stamp_text(DECK)
+        assert "abc1234567" in new_text
+
+    def test_uid_inserted_before_existing_tag(self):
+        new_text, _ = stamp_text(DECK)
+        # the stamped uid for q2 comes immediately before its [^tag]
+        assert re.search(r"\[\^uid\]: [A-Za-z0-9]{10}\n\[\^tag\]: x", new_text)
+
+    def test_idempotent(self):
+        once, _ = stamp_text(DECK)
+        twice, lines = stamp_text(once)
+        assert lines == []
+        assert twice == once
+
+    def test_no_card_blocks_is_noop(self):
+        text = "---\ndeck: foo\n---\njust prose, no blocks\n"
+        new_text, lines = stamp_text(text)
+        assert lines == []
+        assert new_text == text
+
+    def test_clean_file_returned_byte_for_byte(self):
+        # no trailing newline, already has uid -> must be returned unchanged
+        text = "---\ndeck: foo\n---\n---\n\nq ::: a\n\n---\n[^uid]: abc1234567"
+        new_text, lines = stamp_text(text)
+        assert lines == []
+        assert new_text == text
+
+    def test_stamps_block_at_eof_without_trailing_newline(self):
+        text = "---\ndeck: foo\n---\n---\n\nq ::: a\n\n---"
+        new_text, lines = stamp_text(text)
+        assert len(lines) == 1
+        assert _UID_LINE.search(new_text)
+
+
+class TestStampFile:
+    def test_writes_atomically_and_preserves_unrelated_content(self, tmp_path):
+        path = tmp_path / "deck.md"
+        path.write_text(DECK)
+        result = stamp_file(path, tmp_path, dry_run=False)
+        assert len(result.stamped_lines) == 2
+        assert len(_UID_LINE.findall(path.read_text())) == 3
+
+    def test_dry_run_does_not_write(self, tmp_path):
+        path = tmp_path / "deck.md"
+        path.write_text(DECK)
+        before = path.read_text()
+        result = stamp_file(path, tmp_path, dry_run=True)
+        assert result.stamped_lines  # reports work
+        assert path.read_text() == before  # but writes nothing
+
+    def test_preserves_file_mode(self, tmp_path):
+        path = tmp_path / "deck.md"
+        path.write_text(DECK)
+        path.chmod(0o640)
+        stamp_file(path, tmp_path, dry_run=False)
+        assert (path.stat().st_mode & 0o777) == 0o640
+
+    def test_symlink_skipped(self, tmp_path):
+        real = tmp_path / "real.md"
+        real.write_text(DECK)
+        link = tmp_path / "link.md"
+        link.symlink_to(real)
+        result = stamp_file(link, tmp_path, dry_run=False)
+        assert result.skipped_reason == "symlink"
+        assert not result.stamped_lines
+
+    def test_crlf_file_skipped_not_mangled(self, tmp_path):
+        path = tmp_path / "deck.md"
+        path.write_bytes(DECK.replace("\n", "\r\n").encode("utf-8"))
+        before = path.read_bytes()
+        result = stamp_file(path, tmp_path, dry_run=False)
+        assert result.skipped_reason == "CRLF line endings not supported"
+        assert path.read_bytes() == before  # untouched
+
+    def test_clean_file_no_change(self, tmp_path):
+        path = tmp_path / "deck.md"
+        path.write_text(
+            "---\ndeck: foo\n---\n---\n\nq ::: a\n\n---\n[^uid]: abc1234567\n"
+        )
+        result = stamp_file(path, tmp_path, dry_run=False)
+        assert result.stamped_lines == []
+
+
+class TestGitGate:
+    @staticmethod
+    def _git(repo, *args):
+        subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+    def test_refuses_dirty_then_stamps_clean(self, tmp_path):
+        from typer.testing import CliRunner
+
+        from app.cli.entry import app
+
+        runner = CliRunner()
+        self._git(tmp_path, "init")
+        self._git(tmp_path, "config", "user.email", "t@t.t")
+        self._git(tmp_path, "config", "user.name", "t")
+
+        deck = tmp_path / "deck.md"
+        deck.write_text(DECK)
+        # dirty (untracked) -> refused
+        result = runner.invoke(app, ["uid", "--path", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "uncommitted changes" in result.stdout
+        assert len(_UID_LINE.findall(deck.read_text())) == 1  # untouched
+
+        # commit -> clean -> stamps
+        self._git(tmp_path, "add", "deck.md")
+        self._git(tmp_path, "commit", "-m", "add")
+        result = runner.invoke(app, ["uid", "--path", str(tmp_path)])
+        assert result.exit_code == 0
+        assert len(_UID_LINE.findall(deck.read_text())) == 3


### PR DESCRIPTION
## Summary
Closes #37. New `ankc uid` command inserts a `[^uid]` footnote into any card block missing one — completing the authoring loop: write cards → `ankc uid` → `ankc build`. Idempotent; `--check` previews (writes nothing, exits 1 if work remains).

## Safety (this command mutates source files)
- **Atomic write**: temp file in the same dir + `os.replace`, `copystat` to preserve mode, cleanup on failure — the original is never at risk. An on-disk-change guard aborts if the file changed since it was read.
- **Convergence post-condition**: a second stamping pass must be a no-op, else the write is refused.
- **Path safety**: symlinks and paths resolving outside the search root are skipped.
- **CRLF**: files with CRLF endings are skipped (not silently normalized to LF).
- **Git gate**: refuses to rewrite files with uncommitted changes (so there's always a revert point) unless `--force`; outside a git repo it proceeds (use `--check` to preview).
- **EOF**: a block ending the file without a trailing newline is still stamped; clean files are returned byte-for-byte.

## Other
- Hoisted shared `frontmatter_end_offset` / `line_at` helpers into `utils.py` (were duplicated in validation/stamping).
- Stamping uses its own block-boundary regex (reusing `NOTE_BODY`), deliberately separate from the validator's semantic regex.

## Verification
- 78 tests pass (`tests/test_stamping.py` covers stamping, idempotency, atomic write, mode preservation, symlink/CRLF skip, EOF, and the git dirty/clean gate); black/flake8/bandit clean.
- Reviewed by code-reviewer, security-analyst, sw-architect. Addressed the CRLF-mangling and wrong-line-number HIGHs and the EOF gap; security found no critical/high (atomic write sound, subprocess safe). Minor pre-existing follow-up noted: `generate_chunk` hardcodes `[^uid]` vs `settings.GUID_KEY`.