### PR TITLE
Add example deck and CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing
+
+## Development setup
+
+This project uses [PDM](https://pdm-project.org/).
+
+```sh
+pdm install        # install runtime + dev dependencies
+```
+
+## Checks
+
+CI runs the same checks on every pull request. Run them locally before pushing:
+
+```sh
+pdm run check      # release-version check + format + security + tests
+```
+
+Individual steps:
+
+| Command | What it does |
+|---|---|
+| `pdm run format` | `black --check .` |
+| `pdm run secure` | `bandit -r app -ll` |
+| `pdm run test` | `pytest` |
+| `pdm run coverage` | tests with coverage report |
+
+## Branching
+
+Branch off `dev` and open pull requests against `dev` (not `main`):
+
+```sh
+git switch dev
+git switch -c fix/<issue>-short-description
+```
+
+Use `fix/`, `feature/`, or `docs/` prefixes. Keep `app/config.py` `VERSION`
+and `pyproject.toml` `version` in sync — the release check enforces it; bump
+them together (minor for behavior changes, patch for fixes).
+
+## Authoring decks
+
+See [`examples/example.md`](examples/example.md) for a deck exercising every
+note type, tags, and math, and the README for the format. Useful while editing:
+
+```sh
+ankc check --deck <name> --path <dir>   # validate without compiling
+ankc uid --path <dir>                   # stamp any card blocks missing a uid
+```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Key commands:
 - `ankc check` — validate decks without compiling; reports problems with `file:line` (`--format json` available).
 - `ankc uid` — insert a `[^uid]` footnote into any card block missing one (idempotent; `--check` for a dry run). Refuses to rewrite files with uncommitted git changes unless `--force`.
 ### Examples
-An example source deck can be found in the [test deck](https://github.com/QuinnHerden/ankcompiler/blob/main/tests/decks/sample.md)
+See [`examples/example.md`](examples/example.md) for a deck exercising every note type, tags, and math.
 ### Note types
 - **Question/Answer** — `front ::: back` (detected automatically).
 - **Cloze** — `{{c1:: ...}}` (detected automatically).

--- a/examples/example.md
+++ b/examples/example.md
@@ -1,0 +1,59 @@
+---
+deck: AnkCompiler Example
+tags:
+  - example
+---
+
+A source deck is YAML frontmatter (above) followed by card blocks. Prose like
+this paragraph is ignored — only the `---`-delimited blocks become cards. Each
+block is followed by footnotes: a required `[^uid]` (stable card identity, so
+re-importing updates rather than duplicates) and optional `[^tag]` / `[^type]`.
+
+---
+
+What is the capital of France? ::: Paris
+
+---
+[^uid]: aaAA11bb22
+
+---
+
+A question and answer
+:::
+may also span multiple lines.
+
+---
+[^uid]: ccCC33dd44
+[^tag]: geography
+
+---
+
+Cloze deletions use {{c1:: curly braces}} and are detected automatically.
+
+---
+[^uid]: eeEE55ff66
+
+---
+
+front ::: back
+
+---
+[^uid]: ggGG77hh88
+[^type]: reversed
+
+---
+
+What is 9 times 6? ::: 54
+
+---
+[^uid]: iiII99jj00
+[^type]: type-in
+
+---
+
+Inline ($...$) and block ($$...$$) LaTeX render via Anki's MathJax.
+Area of a circle with radius $r$? ::: $A = \pi r^2$
+
+---
+[^uid]: kkKKllmmNN
+[^tag]: math


### PR DESCRIPTION
## Summary
Adds authoring/contributor documentation. No code changes.

- **`examples/example.md`** — a readable deck demonstrating every note type (QA one-line + multi-line, cloze, `[^type]: reversed`, `[^type]: type-in`), frontmatter and per-note tags, and inline math. Validates (`ankc check`) and builds (`ankc build`) clean.
- **`CONTRIBUTING.md`** — PDM dev setup, the checks CI runs (`pdm run check` and the individual steps), the branch-off-`dev` → PR-into-`dev` workflow, the version-sync requirement, and the deck-authoring commands (`ankc check`, `ankc uid`).
- **README** — Examples section now points at `examples/example.md`.

## Verification
- 78 tests still pass; `ankc check --all --path examples` reports no problems and the deck builds.