### PR TITLE
Rewrite docs in plain style without em dashes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,40 +10,41 @@ pdm install        # install runtime + dev dependencies
 
 ## Checks
 
-CI runs the same checks on every pull request. Run them locally before pushing:
+CI runs the same checks on every pull request. Run them before you push:
 
 ```sh
-pdm run check      # release-version check + format + security + tests
+pdm run check      # release-version check, format, security, tests
 ```
 
-Individual steps:
+You can also run each step on its own:
 
 | Command | What it does |
 |---|---|
 | `pdm run format` | `black --check .` |
 | `pdm run secure` | `bandit -r app -ll` |
 | `pdm run test` | `pytest` |
-| `pdm run coverage` | tests with coverage report |
+| `pdm run coverage` | tests with a coverage report |
 
 ## Branching
 
-Branch off `dev` and open pull requests against `dev` (not `main`):
+Branch off `dev` and open pull requests against `dev`, not `main`.
 
 ```sh
 git switch dev
 git switch -c fix/<issue>-short-description
 ```
 
-Use `fix/`, `feature/`, or `docs/` prefixes. Keep `app/config.py` `VERSION`
-and `pyproject.toml` `version` in sync — the release check enforces it; bump
-them together (minor for behavior changes, patch for fixes).
+Use a `fix/`, `feature/`, or `docs/` prefix. Keep the `VERSION` in `app/config.py`
+and the `version` in `pyproject.toml` the same. The release check fails if they
+differ, so bump both together. Use a minor bump for a behavior change and a patch
+bump for a fix.
 
 ## Authoring decks
 
-See [`examples/example.md`](examples/example.md) for a deck exercising every
-note type, tags, and math, and the README for the format. Useful while editing:
+See [`examples/example.md`](examples/example.md) for a deck with every note type,
+tags, and math. The README explains the format. These commands help while you edit:
 
 ```sh
 ankc check --deck <name> --path <dir>   # validate without compiling
-ankc uid --path <dir>                   # stamp any card blocks missing a uid
+ankc uid --path <dir>                   # add a uid to any card block missing one
 ```

--- a/README.md
+++ b/README.md
@@ -7,20 +7,20 @@ Run `pip install ankcompiler`
 ## Usage
 Run `ankc --help` for usage information.
 
-Key commands:
-- `ankc build` — compile decks into `.apkg` packages.
-- `ankc check` — validate decks without compiling; reports problems with `file:line` (`--format json` available).
-- `ankc uid` — insert a `[^uid]` footnote into any card block missing one (idempotent; `--check` for a dry run). Refuses to rewrite files with uncommitted git changes unless `--force`.
+Main commands:
+- `ankc build` compiles decks into `.apkg` packages.
+- `ankc check` validates decks without compiling. It reports problems as `file:line`, and can print JSON with `--format json`.
+- `ankc uid` adds a `[^uid]` footnote to any card block that is missing one. It is safe to run more than once. Use `--check` for a dry run. It will not touch files with uncommitted git changes unless you pass `--force`.
 ### Examples
-See [`examples/example.md`](examples/example.md) for a deck exercising every note type, tags, and math.
+See [`examples/example.md`](examples/example.md) for a deck with every note type, tags, and math.
 ### Note types
-- **Question/Answer** — `front ::: back` (detected automatically).
-- **Cloze** — `{{c1:: ...}}` (detected automatically).
-- **Basic-and-reversed** — `front ::: back` with `[^type]: reversed`; generates both directions.
-- **Type-in-answer** — `question ::: answer` with `[^type]: type-in`.
+- Question and answer: `front ::: back`. Found automatically.
+- Cloze: `{{c1:: ...}}`. Found automatically.
+- Basic and reversed: `front ::: back` plus `[^type]: reversed`. This makes a card in both directions.
+- Type in the answer: `question ::: answer` plus `[^type]: type-in`.
 
-Reversed and type-in cards share the `:::` syntax, so declare them explicitly with a `[^type]` footnote alongside `[^uid]`.
+Reversed and type-in cards use the same `:::` syntax as a question and answer card. So you name them with a `[^type]` footnote next to the `[^uid]`.
 ### Math
-Inline (`$...$`) and block (`$$...$$`) LaTeX is rendered by Anki's MathJax. Use `\$` for a literal dollar sign.
+Write inline math as `$...$` and block math as `$$...$$`. Anki renders it with MathJax. To show a real dollar sign, write `\$`.
 ## Credits
 Inspiration taken from [lukesmurry](https://github.com/lukesmurray/markdown-anki-decks)

--- a/examples/example.md
+++ b/examples/example.md
@@ -5,9 +5,10 @@ tags:
 ---
 
 A source deck is YAML frontmatter (above) followed by card blocks. Prose like
-this paragraph is ignored — only the `---`-delimited blocks become cards. Each
-block is followed by footnotes: a required `[^uid]` (stable card identity, so
-re-importing updates rather than duplicates) and optional `[^tag]` / `[^type]`.
+this paragraph is ignored. Only the `---` blocks become cards. Each block is
+followed by footnotes. The `[^uid]` is required. It gives the card a stable id,
+so re-importing updates the card instead of making a duplicate. The `[^tag]` and
+`[^type]` footnotes are optional.
 
 ---
 


### PR DESCRIPTION
## Summary
Fixes the writing style in the docs I added earlier. Removes every em dash, drops the bold-lead bullet pattern, and uses simpler words and shorter sentences. Applies to README.md, CONTRIBUTING.md, and examples/example.md. No content or command changes.

CONTRIBUTING still documents PDM because that is the current build tool. Issue #48 tracks the migration to uv and will update those commands.

## Verification
- `pdm run check` passes: 78 tests, format clean, bandit severity High and Medium both 0.
- Three agents reviewed: a style pass confirmed no em dashes, no bold-lead bullets, and no AI-tell phrases; code-reviewer confirmed every command and syntax claim matches the code and the example builds; architect confirmed the structure is sound.