### PR TITLE
Give Chunk a public validate() API for the validator (#45)

### DIFF
--- a/app/logic/sources.py
+++ b/app/logic/sources.py
@@ -216,6 +216,31 @@ class Chunk:
 
         return note
 
+    @property
+    def uid(self) -> Optional[str]:
+        """The note's declared uid, or None if it has none."""
+        return self._extract_meta().get(settings.GUID_KEY)
+
+    def validate(self) -> List[str]:
+        """Returns chunk-level validation errors, empty when the chunk is
+        valid. Covers a missing uid and an unresolvable or mismatched note
+        type. Deck-level checks (duplicate uid, frontmatter) live in the
+        caller."""
+        errors: List[str] = []
+        meta_dict = self._extract_meta()
+
+        if meta_dict.get(settings.GUID_KEY) is None:
+            snippet = self.body.strip().splitlines()[0][:50]
+            errors.append(f'card block missing uid: "{snippet}"')
+
+        try:
+            note_type = self._resolve_type(meta_dict)
+            self._extract_md_fields(note_type)
+        except ValueError as exc:
+            errors.append(str(exc))
+
+        return errors
+
     def _extract_meta(self) -> dict:
         """
         Extracts footer metadata from note chunk.
@@ -250,10 +275,6 @@ class Chunk:
                 meta_dict[key] = value
 
         return meta_dict
-
-    def _extract_type(self) -> "NoteType":
-        """Resolves the note type for this chunk (parsing meta on demand)."""
-        return self._resolve_type(self._extract_meta())
 
     def _resolve_type(self, meta_dict: dict) -> "NoteType":
         """Resolves the note type from already-parsed metadata.

--- a/app/logic/validation.py
+++ b/app/logic/validation.py
@@ -87,34 +87,26 @@ def _validate_chunk(
     chunk: Chunk, path: Path, line: int, seen_uids: Dict[str, Tuple[Path, int]]
 ) -> List[Finding]:
     findings: List[Finding] = []
-    meta = chunk._extract_meta()
 
-    uid = meta.get(settings.GUID_KEY)
-    if uid is None:
-        snippet = chunk.body.strip().splitlines()[0][:50]
-        findings.append(
-            Finding(path, line, "error", f'card block missing uid — "{snippet}"')
-        )
-    elif uid in seen_uids:
-        prev_file, prev_line = seen_uids[uid]
-        findings.append(
-            Finding(
-                path,
-                line,
-                "error",
-                f"duplicate uid '{uid}' (first seen at {prev_file}:{prev_line})",
+    # Chunk-level validity (missing uid, note type) comes from the chunk
+    # itself; this function adds location and the deck-level duplicate check.
+    for message in chunk.validate():
+        findings.append(Finding(path, line, "error", message))
+
+    uid = chunk.uid
+    if uid is not None:
+        if uid in seen_uids:
+            prev_file, prev_line = seen_uids[uid]
+            findings.append(
+                Finding(
+                    path,
+                    line,
+                    "error",
+                    f"duplicate uid '{uid}' (first seen at {prev_file}:{prev_line})",
+                )
             )
-        )
-    else:
-        seen_uids[uid] = (path, line)
-
-    # Type resolution + field extraction reuse the production logic; surface
-    # their errors as findings with location instead of aborting.
-    try:
-        note_type = chunk._resolve_type(meta)
-        chunk._extract_md_fields(note_type)
-    except ValueError as exc:
-        findings.append(Finding(path, line, "error", str(exc)))
+        else:
+            seen_uids[uid] = (path, line)
 
     return findings
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -59,16 +59,40 @@ class TestDeclaredNoteType:
 
 class TestExtractType:
     @staticmethod
-    def test_no_matching_type_raises():
-        chunk = Chunk(meta="", body="just some plain prose, no card syntax", file=None)
-        with pytest.raises(ValueError, match="Could not find a note type"):
-            chunk._extract_type()
+    def test_no_matching_type_reported():
+        chunk = Chunk(
+            meta="[^uid]: abc1234567", body="plain prose, no card syntax", file=None
+        )
+        assert any("Could not find a note type" in e for e in chunk.validate())
 
     @staticmethod
-    def test_ambiguous_type_raises():
-        chunk = Chunk(meta="", body="front ::: back {{c1:: cloze}}", file=None)
-        with pytest.raises(ValueError, match="Found more than one note type"):
-            chunk._extract_type()
+    def test_ambiguous_type_reported():
+        chunk = Chunk(
+            meta="[^uid]: abc1234567", body="front ::: back {{c1:: cloze}}", file=None
+        )
+        assert any("Found more than one note type" in e for e in chunk.validate())
+
+
+class TestChunkValidate:
+    @staticmethod
+    def test_valid_chunk_has_no_errors_and_exposes_uid():
+        chunk = Chunk(meta="[^uid]: abc1234567", body="q ::: a", file=None)
+        assert chunk.validate() == []
+        assert chunk.uid == "abc1234567"
+
+    @staticmethod
+    def test_missing_uid_reported_and_uid_none():
+        chunk = Chunk(meta="", body="q ::: a", file=None)
+        errors = chunk.validate()
+        assert any("missing uid" in e for e in errors)
+        assert chunk.uid is None
+
+    @staticmethod
+    def test_unknown_type_reported():
+        chunk = Chunk(
+            meta="[^uid]: abc1234567\n[^type]: bogus", body="q ::: a", file=None
+        )
+        assert any("Unknown note type 'bogus'" in e for e in chunk.validate())
 
 
 class TestExtractMeta:


### PR DESCRIPTION
## Summary
Closes #45. The validator called `Chunk._extract_meta`, `_resolve_type`, and `_extract_md_fields` (private), which coupled it to Chunk internals. Now Chunk exposes a public `validate() -> list[str]` (missing-uid and note-type errors) and a `uid` property. `validation.py` calls those and keeps the file/deck-level concerns (frontmatter, duplicate uid, line numbers, malformed blocks).

## Changes
- `Chunk.validate()` and `Chunk.uid` added; `validation._validate_chunk` uses only those public members.
- Removed the now-unused `_extract_type` wrapper; its two tests now exercise `validate()`.
- Changed the missing-uid message from an em dash to a colon (writing-style fix).

## Verification
- `make check` green: 81 tests (3 new for `validate`/`uid`), format/bandit clean. `ankc check` still works on the example deck.
- Reviewed by code-reviewer (behavior preserved, no missed/doubled findings), sw-architect (boundary clean, no leftover private coupling or dead imports; flagged the dead `_extract_type`, now removed), security-analyst (snippet flow unchanged, no new failure path). No critical/high.