### PR TITLE
Publish to PyPI via Trusted Publishing (OIDC) (#51)

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -12,8 +12,13 @@ jobs:
     if: github.event.pull_request.merged
 
     runs-on: ubuntu-latest
+
+    # OIDC token for PyPI Trusted Publishing (no stored credentials).
+    permissions:
+      id-token: write
+
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
@@ -26,10 +31,9 @@ jobs:
           rm -rf dist
           uv build
 
+      # No credentials: uv detects the GitHub OIDC token and uses PyPI
+      # Trusted Publishing. Requires a trusted publisher configured on PyPI
+      # for this repo and workflow (owner QuinnHerden, repo ankcompiler,
+      # workflow deployment.yml).
       - name: Publish
         run: uv publish
-        env:
-          # Secret names are legacy (pre-uv); the values are the PyPI
-          # token credentials. See #51 to move to Trusted Publishing.
-          UV_PUBLISH_USERNAME: ${{ secrets.PDM_PUBLISH_USERNAME }}
-          UV_PUBLISH_PASSWORD: ${{ secrets.PDM_PUBLISH_PASSWORD }}


### PR DESCRIPTION
## Summary
Closes #51. Replaces the stored PyPI username/password with Trusted Publishing (OIDC). The deployment job gets `permissions: id-token: write`, and `uv publish` mints a short-lived OIDC token (its default `--trusted-publishing automatic`). No stored release credential.

## Changes
- deployment.yml: job-level `id-token: write`; removed the `UV_PUBLISH_USERNAME/PASSWORD` env block; `uv publish` runs with no credentials.
- SHA-pinned `actions/checkout` in this job, since it now holds the OIDC token (security review item).

## Required setup before the next release (cannot publish without it)
1. On PyPI, add a trusted publisher for the `ankcompiler` project: owner `QuinnHerden`, repository `ankcompiler`, workflow filename `deployment.yml`, environment left blank. PyPI keys on the workflow filename, so do not rename `deployment.yml`.
2. After a successful OIDC release, delete the `PDM_PUBLISH_USERNAME` / `PDM_PUBLISH_PASSWORD` repo secrets and revoke the old PyPI API token (a deleted secret alone leaves a live token).

## Review
Reviewed by code-reviewer, sw-architect, security-analyst. No critical/high; it is a net security improvement (no long-lived credential). All three flagged the PyPI prerequisite above. `id-token: write` is correctly job-scoped and minimal.