### PR TITLE
Bind the deploy job to a release environment

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -13,6 +13,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # Matches the GitHub environment named in the PyPI trusted publisher.
+    # Add protection rules (e.g. required reviewers) under repo settings.
+    environment: release
+
     # OIDC token for PyPI Trusted Publishing (no stored credentials).
     permissions:
       id-token: write
@@ -33,7 +37,7 @@ jobs:
 
       # No credentials: uv detects the GitHub OIDC token and uses PyPI
       # Trusted Publishing. Requires a trusted publisher configured on PyPI
-      # for this repo and workflow (owner QuinnHerden, repo ankcompiler,
-      # workflow deployment.yml).
+      # for this repo (owner QuinnHerden, repo ankcompiler, workflow
+      # deployment.yml, environment release).
       - name: Publish
         run: uv publish


### PR DESCRIPTION
## Summary
Sets `environment: release` on the deployment job so it matches the PyPI trusted publisher configured with environment name `release`. This tightens the OIDC subject claim (`...:environment:release`) and unlocks optional protection rules on the environment.

## Notes
- GitHub auto-creates the `release` environment on first run, but to get a required-reviewer gate and a branch limit, create it explicitly under repo Settings, Environments.
- The PyPI trusted publisher's Environment field must be exactly `release` (case-sensitive).

## Review
code-reviewer, sw-architect, security-analyst: clean, no findings. Net posture improvement, no risk introduced; job-scoped, OIDC and merged-PR-to-main gate intact.