### PR TITLE
release: 0.3.0 — ankc uid --fix + strict dropped-card validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Run `ankc --help` for usage information.
 Main commands:
 - `ankc build` compiles decks into `.apkg` packages.
 - `ankc check` validates decks without compiling. It reports problems as `file:line`, and can print JSON with `--format json`.
-- `ankc uid` adds a `[^uid]` footnote to any card block that is missing one. It is safe to run more than once. Use `--check` for a dry run. It will not touch files with uncommitted git changes unless you pass `--force`.
+- `ankc uid` adds a `[^uid]` footnote to any card block that is missing one. It is append-only and safe to run more than once. Use `--check` for a dry run. It will not touch files with uncommitted git changes unless you pass `--force`.
+  - Add `--fix` to also repair a draft deck whose cards are separated by a single `---`. It rewrites each card into a well-formed block and stamps any missing uids. Draft fast, then run `ankc uid --fix` to make the deck buildable. It only restructures real decks (frontmatter with a `deck:` key), so it is safe on non-drafts.
 ### Examples
 See [`examples/example.md`](examples/example.md) for a deck with every note type, tags, and math.
 ### Note types

--- a/app/cli/uid.py
+++ b/app/cli/uid.py
@@ -4,7 +4,11 @@ from typing import Annotated, Optional
 import typer
 
 from app.cli import DEPTH_HELP_STR, PATH_HELP_STR
-from app.logic.drivers import dirty_source_files, stamp_source_files
+from app.logic.drivers import (
+    dirty_source_files,
+    fix_source_files,
+    stamp_source_files,
+)
 
 uid_app = typer.Typer()
 
@@ -15,25 +19,42 @@ def stamp_uids(
     depth: Annotated[Optional[int], typer.Option(min=0, help=DEPTH_HELP_STR)] = None,
     check: Annotated[
         bool,
-        typer.Option("--check", help="Report what would be stamped; write nothing"),
+        typer.Option("--check", help="Report what would change; write nothing"),
     ] = False,
     force: Annotated[
         bool,
-        typer.Option("--force", help="Stamp even if files have uncommitted changes"),
+        typer.Option("--force", help="Run even if files have uncommitted changes"),
+    ] = False,
+    fix: Annotated[
+        bool,
+        typer.Option(
+            "--fix",
+            help="Repair drafts: expand single-'---'-separated cards into "
+            "well-formed blocks and stamp missing uids (rewrites structure)",
+        ),
     ] = False,
 ) -> None:
-    """Inserts a [^uid] footnote into any card block that lacks one."""
+    """Inserts a [^uid] footnote into any card block that lacks one.
+
+    By default this is append-only and never alters card structure. Pass
+    --fix to additionally normalize a draft whose cards are separated by a
+    single '---' delimiter into well-formed card blocks.
+    """
 
     # Refuse to rewrite files with uncommitted changes so there's always a
     # clean git checkpoint to revert to. --check writes nothing; --force opts out.
     if not check and not force:
         dirty = dirty_source_files(source_search_path=path, source_search_depth=depth)
         if dirty:
-            typer.echo("Refusing to stamp files with uncommitted changes:")
+            typer.echo("Refusing to modify files with uncommitted changes:")
             for dirty_path in dirty:
                 typer.echo(f"  {dirty_path}")
             typer.echo("Commit or stash them first, or pass --force.")
             raise typer.Exit(1)
+
+    if fix:
+        _run_fix(path=path, depth=depth, check=check)
+        return
 
     results = stamp_source_files(
         source_search_path=path, source_search_depth=depth, dry_run=check
@@ -54,4 +75,39 @@ def stamp_uids(
         typer.echo(f"{total} uid(s) {'would be ' if check else ''}added")
 
     if check and total > 0:
+        raise typer.Exit(1)
+
+
+def _run_fix(path: Optional[Path], depth: Optional[int], check: bool) -> None:
+    """Handles `ankc uid --fix`: structural normalization of draft decks."""
+    results = fix_source_files(
+        source_search_path=path, source_search_depth=depth, dry_run=check
+    )
+
+    changed = 0
+    uids = 0
+    had_error = False
+    for result in results:
+        if result.error:
+            had_error = True
+            typer.echo(f"{result.file}: cannot fix — {result.error}")
+        elif result.changed:
+            changed += 1
+            uids += result.uids_added
+            verb = "would reformat" if check else "reformatted"
+            typer.echo(
+                f"{result.file}: {verb} {result.card_count} card(s), "
+                f"{result.uids_added} uid(s) added"
+            )
+
+    if had_error:
+        raise typer.Exit(1)
+
+    if changed == 0:
+        typer.echo("nothing to fix — all decks are well-formed")
+    else:
+        verb = "would be " if check else ""
+        typer.echo(f"{changed} file(s) {verb}reformatted, {uids} uid(s) added")
+
+    if check and changed > 0:
         raise typer.Exit(1)

--- a/app/config.py
+++ b/app/config.py
@@ -4,7 +4,7 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     """Project settings"""
 
-    VERSION: str = "0.2.0"
+    VERSION: str = "0.3.0"
     DECK_TITLE_KEY: str = "deck"
     GUID_KEY: str = "uid"
     TAG_KEY: str = "tag"

--- a/app/logic/drivers.py
+++ b/app/logic/drivers.py
@@ -8,7 +8,13 @@ from app.logic.utils import (
     parse_markdown_file,
     search_markdown_files,
 )
-from app.logic.stamping import StampResult, file_is_dirty, stamp_file
+from app.logic.stamping import (
+    FixResult,
+    StampResult,
+    file_is_dirty,
+    fix_file,
+    stamp_file,
+)
 from app.logic.validation import Finding, validate_files
 
 
@@ -111,6 +117,22 @@ def stamp_source_files(
     )
     return [
         stamp_file(path=path, search_root=source_search_path, dry_run=dry_run)
+        for path in files
+    ]
+
+
+def fix_source_files(
+    source_search_path: Path,
+    source_search_depth: Optional[int],
+    dry_run: bool,
+) -> List[FixResult]:
+    """Normalizes draft card blocks across all markdown files under the search
+    path, expanding single-``---``-separated cards and stamping missing uids."""
+    files = search_markdown_files(
+        search_path=source_search_path, search_depth=source_search_depth
+    )
+    return [
+        fix_file(path=path, search_root=source_search_path, dry_run=dry_run)
         for path in files
     ]
 

--- a/app/logic/stamping.py
+++ b/app/logic/stamping.py
@@ -23,6 +23,19 @@ _BLOCK_RE = re.compile(rf"---\n\s*\n+{NOTE_BODY}\n\s*\n---\n")
 # Contiguous footnote lines immediately following a block.
 _FOOTNOTES_RE = re.compile(r"(?:\[\^\w+\]: *.+?\n)*")
 _UID_RE = re.compile(rf"\[\^{settings.GUID_KEY}\]:")
+# A uid footnote the compiler will accept: exactly 10 alphanumerics. Must stay
+# in sync with GUID_FOOTNOTE in app.logic.sources. A "[^uid]:" footnote whose
+# value is any other shape is malformed and would fail the build.
+_VALID_UID_RE = re.compile(rf"\[\^{settings.GUID_KEY}\]: *[A-Za-z0-9]{{10}} *$")
+
+# A delimiter line: exactly "---" with optional trailing whitespace.
+_SEP_LINE_RE = re.compile(r"^---[ \t]*$")
+# A footnote line: "[^key]: value".
+_FOOTNOTE_LINE_RE = re.compile(r"^\[\^\w+\]: *.+$")
+# Card syntax: a ":::" Q/A separator or a "{{cN::" cloze. Text carrying it
+# outside a well-formed block is an unfenced card; prose without it is left
+# alone (matching the compiler, which ignores non-card prose).
+_CARD_SYNTAX_RE = re.compile(r":::|\{\{ *c\d+ *::")
 
 
 @dataclass
@@ -30,6 +43,16 @@ class StampResult:
     file: Path
     stamped_lines: List[int] = field(default_factory=list)
     skipped_reason: str = ""
+
+
+@dataclass
+class FixResult:
+    file: Path
+    changed: bool = False
+    card_count: int = 0
+    uids_added: int = 0
+    skipped_reason: str = ""
+    error: str = ""
 
 
 def stamp_text(raw: str) -> Tuple[str, List[int]]:
@@ -67,6 +90,161 @@ def stamp_text(raw: str) -> Tuple[str, List[int]]:
     return result, stamped_lines
 
 
+class _FixError(ValueError):
+    """A draft that ``ankc uid --fix`` cannot repair unambiguously."""
+
+
+def _strip_blank_edges(text: str) -> str:
+    """Drops leading/trailing blank lines, preserving internal ones."""
+    lines = text.split("\n")
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    while lines and not lines[-1].strip():
+        lines.pop()
+    return "\n".join(lines)
+
+
+def _is_footnote_region(text: str) -> bool:
+    """True when every non-blank line is a ``[^key]: value`` footnote."""
+    lines = [ln for ln in text.split("\n") if ln.strip()]
+    return bool(lines) and all(_FOOTNOTE_LINE_RE.match(ln.strip()) for ln in lines)
+
+
+def _split_body_and_footnotes(region: str) -> Tuple[str, List[str]]:
+    """Splits a card region into its body and any trailing footnote lines.
+
+    Footnotes normally sit in their own region after the closing ``---``, but a
+    hand-written draft may glue them directly under the answer with no blank
+    line; those would otherwise be absorbed into the card body.
+    """
+    lines = region.split("\n")
+    while lines and not lines[-1].strip():
+        lines.pop()
+    footnotes: List[str] = []
+    while lines and _FOOTNOTE_LINE_RE.match(lines[-1].strip()):
+        footnotes.insert(0, lines.pop().strip())
+    return _strip_blank_edges("\n".join(lines)), footnotes
+
+
+def _has_unfenced_cards(work: str, body_start: int) -> bool:
+    """True when card syntax appears outside every well-formed block.
+
+    This is the only condition that warrants a structural rewrite. When false,
+    the deck is already well-formed (any prose is intentionally ignored) and
+    only uid stamping is needed.
+    """
+    cursor = body_start
+    for match in _BLOCK_RE.finditer(work, body_start):
+        if _CARD_SYNTAX_RE.search(work[cursor : match.start()]):
+            return True
+        end = match.end()
+        following = _FOOTNOTES_RE.match(work, end)
+        if following:
+            end = following.end()
+        cursor = max(cursor, end)
+    return bool(_CARD_SYNTAX_RE.search(work[cursor:]))
+
+
+def fix_text(raw: str) -> Tuple[str, int, int]:
+    """Repairs a draft deck, returning ``(new_text, card_count, uids_added)``.
+
+    When the deck is already well-formed (no card text sits outside a block),
+    this delegates to ``stamp_text``: missing uids are appended and prose is
+    left untouched, so it is safe and idempotent on canonical decks. When a
+    draft has unfenced cards (cards separated by a single ``---``, or content
+    before the first delimiter using the frontmatter's closing ``---`` as the
+    opener), it rebuilds the body into canonical ``---`` / body / ``---`` /
+    ``[^uid]`` blocks, preserving existing footnotes and dropping the obsolete
+    trailing ``.`` sentinel.
+
+    Raises ``_FixError`` for a draft it cannot repair unambiguously (a footnote
+    block with no preceding card).
+
+    Known limit: orphaned card *continuation* lines that carry no card syntax
+    (no ``:::`` / cloze) are indistinguishable from intentional prose and are
+    left to the compiler's own handling rather than rebuilt here.
+    """
+    work = raw if raw.endswith("\n") else raw + "\n"
+    body_start = frontmatter_end_offset(work)
+    frontmatter = work[:body_start]
+
+    # Only restructure genuine decks (frontmatter with a 'deck:' key). Without
+    # that signal a file might be an ordinary note that merely contains "::"; a
+    # structural rewrite there would corrupt it. A non-deck file, or one already
+    # well-formed, gets only append-only stamping, which is always safe.
+    is_deck = bool(
+        re.search(rf"(?m)^{re.escape(settings.DECK_TITLE_KEY)}:", frontmatter)
+    )
+    if not is_deck or not _has_unfenced_cards(work, body_start):
+        new_text, lines = stamp_text(raw)
+        card_count = sum(1 for _ in _BLOCK_RE.finditer(work, body_start))
+        return new_text, card_count, len(lines)
+
+    body = work[body_start:]
+
+    # Drop a trailing legacy "." sentinel before splitting so it doesn't get
+    # mistaken for card content.
+    body = re.sub(r"\n[ \t]*\.[ \t]*\n*\Z", "\n", body)
+
+    # Split the body on delimiter lines into regions.
+    regions: List[str] = []
+    current: List[str] = []
+    for line in body.split("\n"):
+        if _SEP_LINE_RE.match(line):
+            regions.append("\n".join(current))
+            current = []
+        else:
+            current.append(line)
+    regions.append("\n".join(current))
+
+    # Assemble card units: each body region plus any footnote region(s) that
+    # immediately follow it. Content before the first delimiter is the first
+    # card — the frontmatter's closing "---" serves as its opening delimiter,
+    # so a draft needn't repeat it.
+    units: List[Tuple[str, List[str]]] = []  # (body, footnote_lines)
+    for region in regions:
+        if not region.strip():
+            continue
+        if _is_footnote_region(region):
+            if not units:
+                raise _FixError("footnote block with no preceding card")
+            units[-1][1].extend(ln.strip() for ln in region.split("\n") if ln.strip())
+            continue
+        body_text, trailing = _split_body_and_footnotes(region)
+        if not body_text:
+            # The region held only footnotes glued together; attach them.
+            if not units:
+                raise _FixError("footnote block with no preceding card")
+            units[-1][1].extend(trailing)
+            continue
+        units.append((body_text, trailing))
+
+    uids_added = 0
+    rebuilt: List[str] = []
+    for body_text, footnotes in units:
+        # Drop malformed "[^uid]:" lines (a non-10-char value the compiler would
+        # reject); a valid uid is generated below if none survives.
+        footnotes = [
+            ln
+            for ln in footnotes
+            if not (_UID_RE.search(ln) and not _VALID_UID_RE.match(ln))
+        ]
+        if not any(_VALID_UID_RE.match(ln) for ln in footnotes):
+            uid = generate_random_string(length=10)
+            footnotes.insert(0, f"[^{settings.GUID_KEY}]: {uid}")
+            uids_added += 1
+        footblock = "".join(f"{ln}\n" for ln in footnotes)
+        rebuilt.append(f"---\n\n{body_text}\n\n---\n{footblock}")
+
+    new_text = frontmatter + "\n".join(rebuilt)
+
+    # Post-condition: the rebuild must leave no card outside a well-formed block.
+    if _has_unfenced_cards(new_text, frontmatter_end_offset(new_text)):
+        raise _FixError("could not rebuild into well-formed cards")
+
+    return new_text, len(units), uids_added
+
+
 def stamp_file(path: Path, search_root: Path, dry_run: bool) -> StampResult:
     """Stamps a single file, writing atomically. Skips symlinks and any path
     that resolves outside ``search_root``."""
@@ -97,6 +275,40 @@ def stamp_file(path: Path, search_root: Path, dry_run: bool) -> StampResult:
         _atomic_write(path, raw, new_text)
 
     return StampResult(path, stamped_lines=stamped_lines)
+
+
+def fix_file(path: Path, search_root: Path, dry_run: bool) -> FixResult:
+    """Normalizes a single file (see ``fix_text``), writing atomically. Shares
+    ``stamp_file``'s guards: skips symlinks, paths outside ``search_root``, and
+    CRLF files. A draft that cannot be repaired is reported, not written."""
+    if path.is_symlink():
+        return FixResult(path, skipped_reason="symlink")
+
+    resolved = path.resolve()
+    if not resolved.is_relative_to(search_root.resolve()):
+        return FixResult(path, skipped_reason="outside search path")
+
+    if b"\r\n" in path.read_bytes():
+        return FixResult(path, skipped_reason="CRLF line endings not supported")
+
+    raw = read_file(path)
+    try:
+        new_text, card_count, uids_added = fix_text(raw)
+    except _FixError as exc:
+        return FixResult(path, error=str(exc))
+
+    if new_text == raw:
+        return FixResult(path, changed=False, card_count=card_count)
+
+    # Post-condition: a second pass must be a no-op (output is canonical).
+    again, _, _ = fix_text(new_text)
+    if again != new_text:
+        raise RuntimeError(f"fixing {path} did not converge; aborting write")
+
+    if not dry_run:
+        _atomic_write(path, raw, new_text)
+
+    return FixResult(path, changed=True, card_count=card_count, uids_added=uids_added)
 
 
 def file_is_dirty(path: Path) -> Optional[bool]:

--- a/app/logic/validation.py
+++ b/app/logic/validation.py
@@ -25,8 +25,12 @@ _NOTE = rf"(?:---\n\s*\n+(?P<body>{NOTE_BODY})\n\s*\n---\n+)"
 _META = rf"(?P<meta>(?:{GUID_FOOTNOTE}|{TAG_FOOTNOTE}|{TYPE_FOOTNOTE})*)"
 _BLOCK_RE = re.compile(_NOTE + _META)
 
-# Anything that looks like a card opener: a "---" line followed by a blank line.
-_OPENER_RE = re.compile(r"(?m)^---\n\s*\n")
+# A footnote line ("[^uid]: ...") is benign outside a matched block.
+_FOOTNOTE_LINE_RE = re.compile(r"^\[\^\w+\]:")
+# Card syntax: a "::: " Q/A separator or a "{{cN::" cloze. Its presence outside
+# a matched block means a card was meant there but won't compile. Prose without
+# it is intentionally ignored (see examples/example.md), so it is not flagged.
+_CARD_SYNTAX_RE = re.compile(r":::|\{\{ *c\d+ *::")
 
 
 @dataclass
@@ -78,7 +82,7 @@ def _validate_file(path: Path, seen_uids: Dict[str, Tuple[Path, int]]) -> List[F
         chunk = Chunk(body=match.group("body"), meta=match.group("meta"), file=file_obj)
         findings.extend(_validate_chunk(chunk, path, line, seen_uids))
 
-    findings.extend(_check_unparsed_openers(body, body_start, raw, matched_spans, path))
+    findings.extend(_check_dropped_content(body, body_start, raw, matched_spans, path))
 
     return findings
 
@@ -111,29 +115,57 @@ def _validate_chunk(
     return findings
 
 
-def _check_unparsed_openers(
+def _check_dropped_content(
     body: str,
     body_start: int,
     raw: str,
     matched_spans: List[Tuple[int, int]],
     path: Path,
 ) -> List[Finding]:
-    """Flags card-like openers that no well-formed block consumed."""
+    """Flags card-like text that falls outside every well-formed block.
+
+    The compiler only emits notes for text the block grammar matches, and prose
+    outside a block is intentionally ignored (see examples/example.md). But text
+    carrying card syntax ("::" Q/A or a cloze) outside a block is a card that
+    won't compile — usually two cards sharing a single "---" (so the second has
+    no opening delimiter), an unterminated block, or a draft whose cards aren't
+    fenced. That would be silently dropped, so it is reported as an error and the
+    build aborts. Run `ankc uid --fix` to repair a draft.
+    """
     findings: List[Finding] = []
-    for opener in _OPENER_RE.finditer(body):
-        inside = any(start <= opener.start() < end for start, end in matched_spans)
-        if not inside:
-            line = line_at(raw, body_start + opener.start())
-            # Heuristic (a stray "---" in prose can trip it), so warn rather
-            # than error — this must not block an otherwise valid build.
-            findings.append(
-                Finding(
-                    path,
-                    line,
-                    "warning",
-                    "possibly malformed or unterminated card block",
+
+    # Compute the gaps in the body not covered by any matched block span.
+    gaps: List[Tuple[int, int]] = []
+    cursor = 0
+    for start, end in sorted(matched_spans):
+        if start > cursor:
+            gaps.append((cursor, start))
+        cursor = max(cursor, end)
+    if cursor < len(body):
+        gaps.append((cursor, len(body)))
+
+    for gap_start, gap_end in gaps:
+        segment = body[gap_start:gap_end]
+        if not _CARD_SYNTAX_RE.search(segment):
+            continue  # blanks, delimiters, footnotes, or ignored prose
+
+        # Point at the first non-structural line in the gap.
+        offset = gap_start
+        for line in segment.splitlines(keepends=True):
+            stripped = line.strip()
+            if stripped and stripped != "---" and not _FOOTNOTE_LINE_RE.match(stripped):
+                findings.append(
+                    Finding(
+                        path,
+                        line_at(raw, body_start + offset),
+                        "error",
+                        "malformed or unterminated card block — this content is "
+                        "not inside a well-formed card and would be silently "
+                        "dropped (run `ankc uid --fix` to repair a draft)",
+                    )
                 )
-            )
+                break  # one finding per gap is enough to flag the defect
+            offset += len(line)
     return findings
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ankcompiler"
 description = "A CLI tool for compiling Anki decks, defined in Markdown"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
     {name = "Quinn Herden", email = "55929299+QuinnHerden@users.noreply.github.com"},
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -93,6 +93,59 @@ class TestCheck:
         assert "Not a valid source selection." in result.stdout
 
 
+DRAFT_DECK = "---\ndeck: drafty\n---\n" "\nq1 ::: a1\n\n---\n\nq2 ::: a2\n\n---\n"
+
+
+class TestUidFix:
+    @staticmethod
+    def test_fix_reformats_draft(tmp_path):
+        deck = tmp_path / "d.md"
+        deck.write_text(DRAFT_DECK)
+        result = runner.invoke(
+            app, ["uid", "--fix", "--force", "--path", str(tmp_path)]
+        )
+        assert result.exit_code == 0
+        assert "reformatted" in result.stdout
+        assert len(re.findall(r"\[\^uid\]: [A-Za-z0-9]{10}", deck.read_text())) == 2
+
+    @staticmethod
+    def test_fix_check_reports_without_writing(tmp_path):
+        deck = tmp_path / "d.md"
+        deck.write_text(DRAFT_DECK)
+        before = deck.read_text()
+        result = runner.invoke(
+            app, ["uid", "--fix", "--check", "--force", "--path", str(tmp_path)]
+        )
+        assert result.exit_code == 1  # work pending
+        assert "would reformat" in result.stdout
+        assert deck.read_text() == before  # nothing written
+
+    @staticmethod
+    def test_fixed_draft_then_builds(tmp_path):
+        deck_dir = tmp_path / "drafty"
+        deck_dir.mkdir()
+        (deck_dir / "d.md").write_text(DRAFT_DECK)
+        out = tmp_path / "dist"
+        out.mkdir()
+        runner.invoke(app, ["uid", "--fix", "--force", "--path", str(tmp_path)])
+        result = runner.invoke(
+            app,
+            [
+                "build",
+                "--deck",
+                "drafty",
+                "--path",
+                str(tmp_path),
+                "--depth",
+                "2",
+                "--output",
+                str(out),
+            ],
+        )
+        assert result.exit_code == 0
+        assert list(out.glob("*.apkg"))
+
+
 class TestBuild:
     @staticmethod
     def test_build_one():
@@ -138,3 +191,16 @@ class TestBuild:
         )
         assert result.exit_code == 1
         assert "Not a valid source selection." in result.stdout
+
+    @staticmethod
+    def test_build_aborts_on_dropped_card(tmp_path):
+        # an unfixed draft would silently drop cards — build must abort
+        deck_dir = tmp_path / "drafty"
+        deck_dir.mkdir()
+        (deck_dir / "d.md").write_text(DRAFT_DECK)
+        result = runner.invoke(
+            app,
+            ["build", "--deck", "drafty", "--path", str(tmp_path), "--depth", "2"],
+        )
+        assert result.exit_code == 1
+        assert "silently dropped" in result.stdout

--- a/tests/test_stamping.py
+++ b/tests/test_stamping.py
@@ -1,7 +1,8 @@
 import re
 import subprocess
 
-from app.logic.stamping import stamp_file, stamp_text
+from app.logic.stamping import fix_file, fix_text, stamp_file, stamp_text
+from app.logic.validation import validate_files
 
 DECK = (
     "---\ndeck: foo\n---\n"
@@ -101,6 +102,173 @@ class TestStampFile:
         )
         result = stamp_file(path, tmp_path, dry_run=False)
         assert result.stamped_lines == []
+
+
+CANONICAL = (
+    "---\ndeck: foo\n---\n"
+    "---\n\nq1 ::: a1\n\n---\n[^uid]: abc1234567\n"
+    "\n---\n\nq2 ::: a2\n\n---\n[^uid]: def8901234\n"
+)
+
+# A draft: cards separated by a single "---", no uids, first card before the
+# first delimiter, plus a trailing legacy "." sentinel.
+DRAFT = "---\ndeck: foo\n---\n" "\nq1 ::: a1\n\n---\n\nq2 ::: a2\n\n---\n\n.\n"
+
+
+class TestFixText:
+    def test_expands_single_dash_draft(self):
+        new_text, cards, uids = fix_text(DRAFT)
+        assert cards == 2
+        assert uids == 2
+        assert len(_UID_LINE.findall(new_text)) == 2
+        # each card is now wrapped in its own pair of "---" fences
+        assert new_text.count("---\n\nq1 ::: a1\n\n---") == 1
+        assert new_text.count("---\n\nq2 ::: a2\n\n---") == 1
+
+    def test_drops_legacy_sentinel(self):
+        new_text, _, _ = fix_text(DRAFT)
+        # the lone "." sentinel must not survive as content
+        assert "\n.\n" not in new_text
+        assert not new_text.rstrip().endswith(".")
+
+    def test_idempotent_on_canonical(self):
+        new_text, cards, uids = fix_text(CANONICAL)
+        assert cards == 2
+        assert uids == 0
+        assert new_text == CANONICAL  # byte-for-byte
+
+    def test_fix_output_is_a_fixed_point(self):
+        once, _, _ = fix_text(DRAFT)
+        twice, cards, uids = fix_text(once)
+        assert twice == once
+        assert uids == 0
+
+    def test_preserves_existing_uid_and_tag(self):
+        draft = (
+            "---\ndeck: foo\n---\n" "\nq ::: a\n\n---\n[^uid]: keepthis01\n[^tag]: t\n"
+        )
+        new_text, _, uids = fix_text(draft)
+        assert uids == 0
+        assert "keepthis01" in new_text
+        assert "[^tag]: t" in new_text
+
+    def test_no_delimiters_is_noop(self):
+        text = "---\ndeck: foo\n---\njust prose, no card blocks\n"
+        new_text, cards, uids = fix_text(text)
+        assert (cards, uids) == (0, 0)
+        assert new_text == text
+
+    def test_no_frontmatter_not_restructured(self):
+        # a file without a deck: frontmatter is not a deck — never rebuilt
+        # (rebuilding would let frontmatter parsing swallow the first card)
+        draft = "q1 ::: a1\n\n---\n\nq2 ::: a2\n\n---\n"
+        new_text, _, _ = fix_text(draft)
+        assert "q1 ::: a1" in new_text  # content not destroyed
+        assert not new_text.startswith("---\n\nq1")  # not turned into a block
+
+    def test_malformed_existing_uid_regenerated(self):
+        # an existing "[^uid]: short" is not a valid 10-char uid; the compiler
+        # would reject it, so fix must replace it rather than report success
+        draft = (
+            "---\ndeck: foo\n---\n\nq1 ::: a1\n\n---\n[^uid]: short\n\n"
+            "---\n\nq2 ::: a2\n\n---\n"
+        )
+        new_text, cards, uids = fix_text(draft)
+        assert "short" not in new_text
+        assert len(_UID_LINE.findall(new_text)) == 2  # both cards valid uids
+
+    def test_glued_footnote_not_absorbed_into_body(self):
+        # a footnote directly under the answer (no blank line) must be peeled
+        # off, not absorbed into the card body or duplicated
+        draft = (
+            "---\ndeck: foo\n---\n\nq1 ::: a1\n[^uid]: keepthis01\n\n"
+            "---\n\nq2 ::: a2\n\n---\n"
+        )
+        new_text, _, uids = fix_text(draft)
+        assert uids == 1  # q1 keeps its uid; only q2 gets a new one
+        assert "keepthis01" in new_text
+        assert "a1\n[^uid]" not in new_text  # footnote not glued in the body
+
+    def test_footnote_without_card_raises(self):
+        from app.logic.stamping import _FixError
+
+        # a draft (unfenced q2 triggers the rebuild) whose first region is a
+        # footnote with no preceding card — unrepairable
+        bad = (
+            "---\ndeck: foo\n---\n[^uid]: orphan0001\n\n"
+            "---\n\nq1 ::: a1\n\n---\n\nq2 ::: a2\n\n---\n"
+        )
+        try:
+            fix_text(bad)
+            raised = False
+        except _FixError:
+            raised = True
+        assert raised
+
+
+class TestFixFile:
+    def test_reformats_and_writes(self, tmp_path):
+        path = tmp_path / "deck.md"
+        path.write_text(DRAFT)
+        result = fix_file(path, tmp_path, dry_run=False)
+        assert result.changed
+        assert result.card_count == 2
+        assert result.uids_added == 2
+        assert len(_UID_LINE.findall(path.read_text())) == 2
+        # strongest net: the repaired file must validate clean (it builds)
+        assert not [f for f in validate_files([path]) if f.level == "error"]
+
+    def test_repaired_draft_validates_clean(self, tmp_path):
+        # a draft with glued + malformed footnotes, repaired, must validate clean
+        path = tmp_path / "deck.md"
+        path.write_text(
+            "---\ndeck: foo\n---\n\nq1 ::: a1\n[^uid]: short\n\n"
+            "---\n\n{{c1::cloze}} card\n\n---\n\nq3 ::: a3\n\n---\n"
+        )
+        fix_file(path, tmp_path, dry_run=False)
+        assert not [f for f in validate_files([path]) if f.level == "error"]
+
+    def test_dry_run_does_not_write(self, tmp_path):
+        path = tmp_path / "deck.md"
+        path.write_text(DRAFT)
+        before = path.read_text()
+        result = fix_file(path, tmp_path, dry_run=True)
+        assert result.changed
+        assert path.read_text() == before
+
+    def test_canonical_file_unchanged(self, tmp_path):
+        path = tmp_path / "deck.md"
+        path.write_text(CANONICAL)
+        result = fix_file(path, tmp_path, dry_run=False)
+        assert not result.changed
+        assert path.read_text() == CANONICAL
+
+    def test_symlink_skipped(self, tmp_path):
+        real = tmp_path / "real.md"
+        real.write_text(DRAFT)
+        link = tmp_path / "link.md"
+        link.symlink_to(real)
+        result = fix_file(link, tmp_path, dry_run=False)
+        assert result.skipped_reason == "symlink"
+
+    def test_crlf_skipped(self, tmp_path):
+        path = tmp_path / "deck.md"
+        path.write_bytes(DRAFT.replace("\n", "\r\n").encode("utf-8"))
+        before = path.read_bytes()
+        result = fix_file(path, tmp_path, dry_run=False)
+        assert result.skipped_reason == "CRLF line endings not supported"
+        assert path.read_bytes() == before
+
+    def test_unrepairable_draft_reported_not_written(self, tmp_path):
+        path = tmp_path / "deck.md"
+        bad = (
+            "---\ndeck: foo\n---\n[^uid]: orphan0001\n\n"
+            "---\n\nq1 ::: a1\n\n---\n\nq2 ::: a2\n\n---\n"
+        )
+        path.write_text(bad)
+        result = fix_file(path, tmp_path, dry_run=False)
+        assert result.error
+        assert path.read_text() == bad  # untouched
 
 
 class TestGitGate:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -72,6 +72,44 @@ class TestValidateFiles:
         findings = validate_files([path])
         assert any("malformed or unterminated" in f.message for f in findings)
 
+    def test_merged_cards_is_error_not_warning(self, tmp_path):
+        # two cards sharing a single "---": the second has no opening delimiter
+        # and would be silently dropped at compile time. Must be an error so the
+        # build aborts rather than losing the card.
+        path = write_deck(
+            tmp_path,
+            "---\ndeck: foo\n---\n" "---\n\nq1 ::: a1\n\n---\n\nq2 ::: a2\n\n---\n",
+        )
+        findings = validate_files([path])
+        merged = [f for f in findings if "silently dropped" in f.message]
+        assert len(merged) == 1
+        assert merged[0].level == "error"
+
+    def test_prose_outside_block_not_flagged(self, tmp_path):
+        # explanatory prose before the first card block is intentionally
+        # ignored (see examples/example.md), not a dropped card
+        path = write_deck(
+            tmp_path,
+            "---\ndeck: foo\n---\n"
+            "This paragraph documents the deck and is ignored.\n\n"
+            "---\n\nq ::: a\n\n---\n[^uid]: abc1234567\n",
+        )
+        findings = validate_files([path])
+        assert not any("silently dropped" in f.message for f in findings)
+
+    def test_dropped_cloze_card_flagged(self, tmp_path):
+        # a cloze card sharing a single "---" with its neighbor would be dropped
+        path = write_deck(
+            tmp_path,
+            "---\ndeck: foo\n---\n"
+            "---\n\nq1 ::: a1\n\n---\n[^uid]: abc1234567\n\n"
+            "{{c1::orphaned}} cloze\n\n---\n",
+        )
+        findings = validate_files([path])
+        dropped = [f for f in findings if "silently dropped" in f.message]
+        assert len(dropped) == 1
+        assert dropped[0].level == "error"
+
     def test_finding_reports_line_number(self, tmp_path):
         path = write_deck(tmp_path, "---\ndeck: foo\n---\n---\n\nq ::: a\n\n---\n")
         findings = validate_files([path])

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "ankcompiler"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "dataclasses" },


### PR DESCRIPTION
Release 0.3.0 to PyPI.

- `ankc uid --fix`: repair single-`---` draft decks into well-formed card blocks + stamp uids (gated; plain `ankc uid` stays append-only).
- Validation: card text outside a well-formed block is now an error, so `build` aborts instead of silently dropping a card.
- 105 tests; `make format`/`secure`/`coverage` green.

Merging publishes 0.3.0 via the deployment workflow (Trusted Publishing).